### PR TITLE
Update casa6 master

### DIFF
--- a/imageanalysis/CMakeLists.txt
+++ b/imageanalysis/CMakeLists.txt
@@ -383,26 +383,24 @@ install (FILES
         DESTINATION include/casacode/components/SpectralComponents
 )
 
-#
-# replace the syntax "throw(error)" with "noexcept(false)" for C++17 (or later) compiler
-#
+
 add_custom_target(
     modify_variant_h
-    COMMAND bash -c "cp ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}"
-    COMMAND bash -c "sed -e 's/throw(error)/noexcept(false)/g' ${CMAKE_SOURCE_DIR}/variant.h > ${CMAKE_SOURCE_DIR}/variant.h.tmp"
-    COMMAND bash -c "mv ${CMAKE_SOURCE_DIR}/variant.h.tmp ${CMAKE_SOURCE_DIR}/variant.h"
-    VERBATIM
+    COMMAND cp ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/imageanalysis
+    COMMAND sed -e 's/throw[(]error[)]/noexcept(false)/g' ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h > ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h.tmp
+    COMMAND mv ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h.tmp ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h
 )
 
 add_dependencies(casa_imageanalysis modify_variant_h)
+
 
 install (FILES
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/xerces.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/Quantity.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/array.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/record.h
-         # ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h
-         ${CMAKE_SOURCE_DIR}/variant.h # install this revised header instead of the upper one
+         #${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h
+         variant.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/casac.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/version.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/optionparser.h


### PR DESCRIPTION
Updates the casa6 commit to the latest master including carta-related PRs.  Includes updating casacore to Sept 9 commit 5d29aa3. The carta-backend builds with this update.