### PR TITLE
Fixes to allow a clean Debian package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+cmake-build-*/
+imageanalysis/variant.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/
 cmake-build-*/
-imageanalysis/variant.h

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "casa6"]
 	path = casa6
 	url = https://open-bitbucket.nrao.edu/scm/casa/casa6.git
+	ignore = dirty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,13 @@ if (POLICY CMP0074)
 endif()
 
 set(PROJECT_VERSION_MAJOR 3)
-set(PROJECT_VERSION_MINOR 1)
-set(PROJECT_VERSION_PATCH 2)
-set(PROJECT_VERSION 
+set(PROJECT_VERSION_MINOR 4)
+set(PROJECT_VERSION_PATCH 0)
+set(PROJECT_VERSION
   "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
-SET(PROJECT_SOVERSION 3)
+# Increment the PROJECT_SOVERSION every time you update VERSION_MINOR!
+SET(PROJECT_SOVERSION 5)
 
 SET(NO_SOVERSION FALSE CACHE BOOL "do not add version information to shared libraries")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -67,6 +68,7 @@ endif()
 
 # By default do not use ADIOS2, HDF5, FFTW3
 option (ENABLE_TABLELOCKING "Make locking for concurrent table access possible" YES)
+option (USE_READLINE "Build readline support" YES)
 option (USE_ADIOS2 "Build ADIOS2 " NO)
 option (USE_HDF5 "Build HDF5 " NO)
 option (USE_FFTW3 "Use FFTW instead of FFTPack" NO)
@@ -253,8 +255,8 @@ if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif()
 else()
     # Ensure clang is not complaining about unused arguments.
-    set(CMAKE_CXX_FLAGS "-Qunused-arguments ${CMAKE_CXX_FLAGS}")    
-    set(CMAKE_C_FLAGS "-Qunused-arguments ${CMAKE_C_FLAGS}")    
+    set(CMAKE_CXX_FLAGS "-Qunused-arguments ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "-Qunused-arguments ${CMAKE_C_FLAGS}")
 endif()
 
 # Since 2015, we need pwrite and pwrite (POSIX 2001)
@@ -332,7 +334,9 @@ if (GSL_LIBRARY_PATH)
 endif (GSL_LIBRARY_PATH)
 
 find_package (DL)
-find_package (Readline)
+if (USE_READLINE)
+    find_package (Readline REQUIRED)
+endif (USE_READLINE)
 find_package (SOFA)
 if (USE_ADIOS2)
     set(USE_MPI ON)
@@ -371,7 +375,7 @@ if (_usewcs STREQUAL YES)
       message(WARNING "Casacore is not compatible with wcslib 5.14, see issue gh-384.")
     endif (WCSLIB_VERSION_STRING STREQUAL "5.14")
 endif (_usewcs STREQUAL YES)
- 
+
 # Set the include directories and HAVE compiler variables
 include_directories (${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
 if (WCSLIB_FOUND)
@@ -532,8 +536,8 @@ add_subdirectory (imageanalysis)
 foreach (module ${_modules})
     add_subdirectory (casa6/casatools/casacore/${module})
     set_target_properties(
-      casa_${module} 
-      PROPERTIES 
+      casa_${module}
+      PROPERTIES
           VERSION "${LIB_VERSION}"
           SOVERSION "${LIB_SOVERSION}"
     )
@@ -623,7 +627,7 @@ endif (BUILD_PYTHON3)
 #                                or msfits  (fits,ms,msfits,derivedmscal)
 #                                or images  (fits,lattices,mirlib,coordinates,images)
 #                                - all
-# 
+#
 # List of possibly used external packages and where
 #  CFITSIO      fits
 #  WCSLIB       coordinates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,14 +520,25 @@ if (NOT BUILD_TESTING)
     set(EXCL_ALL EXCLUDE_FROM_ALL)
 endif (NOT BUILD_TESTING)
 
+# Custom SOVERSION for imageanalysis is derived from the casa minor version rather than the casacore minor version.
+# Check casa6/casa5/code/CMakeLists.txt, and update these values if they have changed:
+# set( CASA_VERSION_MAJOR   5   )
+# set( CASA_VERSION_MINOR   8   )
+# If the minor version has changed, bump this:
+set( CASA_PROJECT_SOVERSION   1   )
+
 # Determine the SOVERSION and define as compile variable.
 if (casa_soversion)
     set (LIB_VERSION "${casa_soversion}")
     set (LIB_SOVERSION "${casa_soversion}")
     set (CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" )
+    set (CASA_LIB_VERSION "${casa_soversion}")
+    set (CASA_LIB_SOVERSION "${casa_soversion}")
 else( )
     set (LIB_VERSION "${PROJECT_SOVERSION}")
     set (LIB_SOVERSION "${PROJECT_SOVERSION}")
+    set (CASA_LIB_VERSION "${CASA_PROJECT_SOVERSION}")
+    set (CASA_LIB_SOVERSION "${CASA_PROJECT_SOVERSION}")
 endif( )
 
 # Add the modules to be built.
@@ -552,6 +563,13 @@ foreach (module ${_modules})
         endif (${module} STREQUAL scimath_f OR ${module} STREQUAL fits OR ${module} STREQUAL mirlib OR ${module} STREQUAL coordinates)
     endif (APPLE)
 endforeach (module)
+
+set_target_properties(
+      casa_imageanalysis
+      PROPERTIES
+          VERSION "${CASA_LIB_VERSION}"
+          SOVERSION "${CASA_LIB_SOVERSION}"
+)
 
 # Show summary.
 message (STATUS "CMAKE_SYSTEM .......... = ${CMAKE_SYSTEM}")

--- a/imageanalysis/CMakeLists.txt
+++ b/imageanalysis/CMakeLists.txt
@@ -385,13 +385,11 @@ install (FILES
 
 
 add_custom_target(
-    modify_variant_h
-    COMMAND cp ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/imageanalysis
-    COMMAND sed -e 's/throw[(]error[)]/noexcept(false)/g' ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h > ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h.tmp
-    COMMAND mv ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h.tmp ${CMAKE_SOURCE_DIR}/imageanalysis/variant.h
+    patch_stdcasa_variant
+    COMMAND sed -i 's/throw[(]error[)]//g' ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc
 )
 
-add_dependencies(casa_imageanalysis modify_variant_h)
+add_dependencies(casa_imageanalysis patch_stdcasa_variant)
 
 
 install (FILES
@@ -399,8 +397,7 @@ install (FILES
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/Quantity.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/array.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/record.h
-         #${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h
-         variant.h
+         ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/casac.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/version.h
          ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/optionparser.h

--- a/imageanalysis/CMakeLists.txt
+++ b/imageanalysis/CMakeLists.txt
@@ -386,7 +386,8 @@ install (FILES
 
 add_custom_target(
     patch_stdcasa_variant
-    COMMAND sed -i 's/throw[(]error[)]//g' ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc
+    COMMAND sed -i.orig 's/throw[(]error[)]//g' ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc
+    COMMAND rm -f ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h.orig ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc.orig
 )
 
 add_dependencies(casa_imageanalysis patch_stdcasa_variant)


### PR DESCRIPTION
This PR makes several changes to allow the creation of a Debian source package which builds multiple binary packages and is consistent with the format of existing Ubuntu and Kern casacore packages.

1. I updated the main `CMakeLists.txt` file to merge in updates to the casacore `CMakeLists.txt` file in the submodule. I believe that this was always the intention. The casacore shared libraries now have the correct .so.5 suffix (rather than .so.3). This should not interfere with building the code in a CASA environment to get the CASA version suffix. The other merged changes have no effect (readline support is now optional, but defaults to being on).

2. I added an analogous project version for the imageanalysis module, so that the library can be built with version information, and a short version number, to match the casacore shared libraries. This version number is derived from the minor version number of CASA, in the same way that the casacore project version uses the minor version of casacore, and I have started it at 1. The implementation should respect the CASA environment setting, and use the CASA version suffix if it is enabled.

3. There was previously a partial fix in `imageanalysis/CMakeLists.txt` to remove dynamic exception specifications, which are deprecated in C++11 and removed in C++20, from files in `stdcasa`. However, this fix was not modifying the files used in the build; the only effect was that a modified header would be installed at the end. The new fix patches the two files in-place in the submodule. I have edited the submodule configuration so that internal changes are ignored, so that we don't commit the modified submodule state. Following a discussion with @pford I have asked the CASA developers if this fix could be merged into CASA.

We should probably wait to merge this PR until I have finished building the CARTA packages which depend on the package of this code, in case further upstream changes are needed.

Sorry about the reverted reverts; I initially committed this directly to the master branch.