### PR TITLE
Modify ImageMoments and Image2DConvolver codes

### DIFF
--- a/imageanalysis/CMakeLists.txt
+++ b/imageanalysis/CMakeLists.txt
@@ -388,6 +388,10 @@ add_custom_target(
     patch_stdcasa_variant
     COMMAND sed -i.orig 's/throw[(]error[)]//g' ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc
     COMMAND rm -f ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/variant.h.orig ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/stdcasa/StdCasa/variant.cc.orig
+	COMMAND cp ${CMAKE_SOURCE_DIR}/modified_files/ImageMoments.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/imageanalysis/ImageAnalysis
+	COMMAND cp ${CMAKE_SOURCE_DIR}/modified_files/ImageMoments.tcc ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/imageanalysis/ImageAnalysis
+	COMMAND cp ${CMAKE_SOURCE_DIR}/modified_files/Image2DConvolver.h ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/imageanalysis/ImageAnalysis
+	COMMAND cp ${CMAKE_SOURCE_DIR}/modified_files/Image2DConvolver.tcc ${CMAKE_SOURCE_DIR}/${CASA_CODE_PATH}/imageanalysis/ImageAnalysis
 )
 
 add_dependencies(casa_imageanalysis patch_stdcasa_variant)

--- a/modified_files/Image2DConvolver.h
+++ b/modified_files/Image2DConvolver.h
@@ -1,0 +1,259 @@
+//# Image2DConvolver.h: 2D convolution of an image
+//# Copyright (C) 1996,1997,1998,1999,2000,2001,2002,2003
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: Image2DConvolver.h 20229 2008-01-29 15:19:06Z gervandiepen $
+
+#ifndef IMAGES_IMAGE2DCONVOLVER_H
+#define IMAGES_IMAGE2DCONVOLVER_H
+
+#include <imageanalysis/ImageAnalysis/ImageMomentsProgress.h>
+#include <imageanalysis/ImageAnalysis/ImageTask.h>
+
+#include <casa/aips.h>
+#include <casa/Arrays/Array.h>
+#include <scimath/Mathematics/VectorKernel.h>
+#include <casa/Quanta/Quantum.h>
+
+namespace casacore {
+
+template <class T> class ImageInterface;
+template <class T> class Matrix;
+template <class T> class Vector;
+class String;
+class IPosition;
+class CoordinateSystem;
+class ImageInfo;
+class Unit;
+class GaussianBeam;
+}
+
+namespace casa {
+
+// <summary>
+// This class does 2D convolution of an image by a functional form
+// </summary>
+
+// <use visibility=export>
+
+// <reviewed reviewer="" date="yyyy/mm/dd" tests="" demos="">
+// </reviewed>
+
+// <prerequisite>
+//   <li> <linkto class="casacore::ImageInterface">casacore::ImageInterface</linkto>
+//   <li> <linkto class="casacore::Convolver">casacore::Convolver</linkto>
+// </prerequisite>
+
+// <etymology>
+// This class handles 2D convolution of images 
+// </etymology>
+
+// <synopsis>
+// This class convolves an image by a specified 2D function.
+// </synopsis>
+
+// <example>
+// <srcBlock>
+// </srcBlock>
+// </example>
+
+// <motivation>
+// Convolution is a standard image processing requirement.  The
+// class object has no state.
+// The convolution is done via FFT.  Thus input pixels which
+// are masked are set to 0 before the convolution.  The mask
+// is transferred to the output image.  No additional scaling
+// of the output image values is done.
+// 
+// </motivation>
+
+// <todo asof="2001/08/28">
+//   <li> 
+// </todo>
+
+template <class T> class Image2DConvolver : public ImageTask<T> {
+public:
+
+    const static casacore::String CLASS_NAME;
+
+    Image2DConvolver() = delete;
+
+    Image2DConvolver(
+        const SPCIIT image, const casacore::Record *const &regionPtr,
+        const casacore::String& mask, const casacore::String& outname,
+        const casacore::Bool overwrite,
+        casa::ImageMomentsProgress* progressMonitor = nullptr
+    );
+    
+    Image2DConvolver(const Image2DConvolver<T> &other) = delete;
+
+    ~Image2DConvolver() {}
+
+    Image2DConvolver &operator=(const Image2DConvolver<T> &other) = delete;
+
+    SPIIT convolve();
+
+    // type is a string that starts with "g" (gaussian), "b" (boxcar), or "h"
+    // (hanning), and is case insensitive
+    void setKernel(
+        const casacore::String& type, const casacore::Quantity& major,
+        const casacore::Quantity& minor, const casacore::Quantity& pa
+    );
+
+    void setScale(casacore::Double d) { _scale = d; }
+
+    void setAxes(const std::pair<casacore::uInt, casacore::uInt>& axes);
+
+    void setTargetRes(casacore::Bool b) { _targetres = b; }
+
+    casacore::String getClass() const { return CLASS_NAME; }
+
+    // if true, do not log certain info/warning messages which would normally
+    // be logged during convolution
+    void setSuppressWarnings(casacore::Bool b) { _suppressWarnings = b; }
+
+    void stopCalculation();
+
+    casacore::uInt getTotalSteps() {
+        return _totalSteps;
+    }
+
+protected:
+
+       CasacRegionManager::StokesControl _getStokesControl() const {
+           return CasacRegionManager::USE_ALL_STOKES;
+       }
+
+    std::vector<casacore::Coordinate::Type> _getNecessaryCoordinates() const {
+        return std::vector<casacore::Coordinate::Type>();
+    }
+
+    inline casacore::Bool _supportsMultipleRegions() const {return true;}
+
+private:
+    casacore::VectorKernel::KernelTypes _type;
+    casacore::Double _scale;
+    casacore::Quantity _major, _minor, _pa;
+    casacore::IPosition _axes;
+    casacore::Bool _targetres = casacore::False;
+    casacore::Bool _suppressWarnings = casacore::False;
+
+    // used for cancellation
+    volatile bool _stop;
+
+    // used to report the progress
+    casa::ImageMomentsProgress* _progressMonitor;
+
+    // total number of steps for the beam convolution
+    mutable casacore::uInt _totalSteps;
+
+    void _checkKernelParameters(
+        casacore::VectorKernel::KernelTypes kernelType,
+        const casacore::Vector<casacore::Quantity>& parameters
+    ) const;
+
+    void _convolve(
+        SPIIT imageOut, const casacore::ImageInterface<T>& imageIn,
+        casacore::VectorKernel::KernelTypes kernelType
+    ) const;
+
+    // returns the value by which pixel values will be scaled
+    Double _dealWithRestoringBeam (
+        casacore::String& brightnessUnitOut, casacore::GaussianBeam& beamOut,
+        const casacore::Array<Double>& kernelArray, Double kernelVolume,
+        const casacore::VectorKernel::KernelTypes kernelType,
+        const casacore::Vector<casacore::Quantity>& parameters,
+        const casacore::CoordinateSystem& cSys,
+        const casacore::GaussianBeam& beamIn,
+        const casacore::Unit& brightnessUnit, casacore::Bool emitMessage
+    ) const;
+
+    void _doMultipleBeams(
+        ImageInfo& iiOut, Double& kernelVolume, SPIIT imageOut,
+        String& brightnessUnitOut, GaussianBeam& beamOut, Double factor1,
+        const ImageInterface<T>& imageIn, const std::vector<Quantity>& originalParms,
+        std::vector<Quantity>& kernelParms, Array<Double>& kernel,
+        VectorKernel::KernelTypes kernelType, Bool logFactors, Double pixelArea
+    ) const;
+
+    // The kernel is currently always real-valued, so make it Double at this
+    // point to avoid unnecessary templating issues if the image has is
+    // complex valued
+    void _doSingleBeam(
+        ImageInfo& iiOut, Double& kernelVolume, std::vector<Quantity>& kernelParms,
+        Array<Double>& kernel, String& brightnessUnitOut, GaussianBeam& beamOut,
+        SPIIT imageOut, const ImageInterface<T>& imageIn,
+        const std::vector<Quantity>& originalParms,
+        VectorKernel::KernelTypes kernelType, Bool logFactors, Double factor1,
+        Double pixelArea
+    ) const;
+
+    Double _fillKernel (
+        casacore::Matrix<Double>& kernelMatrix,
+        casacore::VectorKernel::KernelTypes kernelType,
+        const casacore::IPosition& kernelShape,
+        const casacore::Vector<casacore::Double>& parameters
+    ) const;
+
+    void _fillGaussian(
+        Double& maxVal, Double& volume, casacore::Matrix<Double>& pixels,
+        Double height, Double xCentre, Double yCentre,
+        Double majorAxis, Double ratio, Double positionAngle
+    ) const;
+
+    Double _makeKernel(
+        casacore::Array<Double>& kernel,
+        casacore::VectorKernel::KernelTypes kernelType,
+        const std::vector<casacore::Quantity>& parameters,
+        const casacore::ImageInterface<T>& inImage
+    ) const;
+
+    casacore::IPosition _shapeOfKernel(
+        const casacore::VectorKernel::KernelTypes kernelType,
+        const casacore::Vector<casacore::Double>& parameters,
+        const casacore::uInt ndim
+    ) const;
+
+    casacore::uInt _sizeOfGaussian(
+        const casacore::Double width, const casacore::Double nSigma
+    ) const;
+
+    std::vector<casacore::Quantity> _getConvolvingBeamForTargetResolution(
+        const std::vector<casacore::Quantity>& targetBeamParms,
+        const casacore::GaussianBeam& inputBeam
+    ) const;
+
+    void _logBeamInfo(
+        const ImageInfo& imageInfo, const String& desc
+    ) const;
+
+    void _log(const String& msg, LogIO::Command priority) const;
+};
+
+}
+
+#ifndef CASACORE_NO_AUTO_TEMPLATES
+#include <imageanalysis/ImageAnalysis/Image2DConvolver.tcc>
+#endif //# CASACORE_NO_AUTO_TEMPLATES
+#endif

--- a/modified_files/Image2DConvolver.tcc
+++ b/modified_files/Image2DConvolver.tcc
@@ -1,0 +1,1001 @@
+//# Image2DConvolver.cc:  convolution of an image by given Array
+//# Copyright (C) 1995,1996,1997,1998,1999,2000,2001,2002
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//   
+#include <imageanalysis/ImageAnalysis/Image2DConvolver.h>
+
+#include <casa/aips.h>
+#include <casa/Arrays/IPosition.h>
+#include <casa/Arrays/Array.h>
+#include <casa/Arrays/ArrayMath.h>
+#include <casa/Arrays/Vector.h>
+#include <casa/Arrays/Matrix.h>
+#include <casa/Exceptions/Error.h>
+#include <components/ComponentModels/GaussianDeconvolver.h>
+#include <components/ComponentModels/GaussianShape.h>
+#include <components/ComponentModels/SkyComponentFactory.h>
+#include <coordinates/Coordinates/CoordinateUtil.h>
+#include <coordinates/Coordinates/CoordinateSystem.h>
+#include <coordinates/Coordinates/DirectionCoordinate.h>
+#include <lattices/LatticeMath/Fit2D.h>
+#include <scimath/Functionals/Gaussian2D.h>
+#include <imageanalysis/ImageAnalysis/ImageConvolver.h>
+#include <imageanalysis/ImageAnalysis/ImageMetaData.h>
+#include <images/Images/PagedImage.h>
+#include <images/Images/TempImage.h>
+#include <images/Images/ImageInterface.h>
+#include <images/Images/ImageInfo.h>
+#include <images/Images/ImageUtilities.h>
+#include <images/Images/SubImage.h>
+#include <casa/Logging/LogIO.h>
+#include <scimath/Mathematics/Convolver.h>
+#include <casa/Quanta/Quantum.h>
+#include <casa/Quanta/MVAngle.h>
+#include <casa/Quanta/Unit.h>
+#include <casa/Quanta/QLogical.h>
+#include <casa/iostream.h>
+
+#include <memory>
+
+namespace casa {
+
+template <class T> const casacore::String Image2DConvolver<T>::CLASS_NAME
+    = "Image2DConvolver";
+
+template <class T> Image2DConvolver<T>::Image2DConvolver(
+    const SPCIIT image, const casacore::Record *const &region,
+    const casacore::String& mask, const casacore::String& outname,
+    const casacore::Bool overwrite,
+    casa::ImageMomentsProgress* progressMonitor
+) : ImageTask<T>(image, "", region, "", "", "", mask, outname, overwrite),
+    _type(casacore::VectorKernel::GAUSSIAN),  _scale(0), _major(), _minor(),
+    _pa(), _axes(image->coordinates().directionAxesNumbers()),
+    _stop(false), _totalSteps(0), _progressMonitor(progressMonitor) {
+    this->_construct(true);
+}
+
+// TODO use GaussianBeams rather than casacore::Vector<casacore::Quantity>s, this method
+// can probably be eliminated.
+template <class T>
+std::vector<casacore::Quantity> Image2DConvolver<T>::_getConvolvingBeamForTargetResolution(
+    const std::vector<casacore::Quantity>& targetBeamParms,
+    const casacore::GaussianBeam& inputBeam
+) const {
+    casacore::GaussianBeam convolvingBeam;
+    casacore::GaussianBeam targetBeam(
+        targetBeamParms[0], targetBeamParms[1],
+        targetBeamParms[2]
+    );
+    try {
+        if(
+            GaussianDeconvolver::deconvolve(
+                convolvingBeam, targetBeam, inputBeam
+            )
+        ) {
+            // point source, or convolvingBeam nonsensical
+            throw casacore::AipsError();
+        }
+    }
+    catch (const casacore::AipsError& x) {
+        ostringstream os;
+        os << "Unable to reach target resolution of " << targetBeam << " Input "
+            << "image beam " << inputBeam << " is (nearly) identical to or "
+            << "larger than the output beam size";
+        ThrowCc(os.str());
+    }
+    std::vector<casacore::Quantity> kernelParms {
+        convolvingBeam.getMajor(),
+        convolvingBeam.getMinor(),
+        convolvingBeam.getPA(true)
+    };
+    return kernelParms;
+}
+
+template <class T> void Image2DConvolver<T>::setAxes(
+    const std::pair<casacore::uInt, casacore::uInt>& axes
+) {
+    casacore::uInt ndim = this->_getImage()->ndim();
+    ThrowIf(axes.first == axes.second, "Axes must be different");
+    ThrowIf(
+        axes.first >= ndim || axes.second >= ndim,
+        "Axis value must be less than number of axes in image"
+    );
+    if (_axes.size() != 2) {
+        _axes.resize(2, false);
+    }
+    _axes[0] = axes.first;
+    _axes[1] = axes.second;
+}
+
+template <class T> void Image2DConvolver<T>::setKernel(
+    const casacore::String& type, const casacore::Quantity& major,
+    const casacore::Quantity& minor, const casacore::Quantity& pa
+) {
+    ThrowIf (major < minor, "Major axis is less than minor axis");
+    _type = casacore::VectorKernel::toKernelType(type);
+    _major = major;
+    _minor = minor;
+    _pa = pa;
+}
+
+template <class T> SPIIT Image2DConvolver<T>::convolve() {
+    _stop = false; // reset the flag for cancellation
+
+    ThrowIf(
+        _axes.nelements() != 2, "You must give two pixel axes to convolve"
+    );
+    auto inc = this->_getImage()->coordinates().increment();
+    auto units = this->_getImage()->coordinates().worldAxisUnits();
+    ThrowIf(
+        ! near (
+            casacore::Quantity(fabs(inc[_axes[0]]), units[_axes[0]]),
+            casacore::Quantity(fabs(inc[_axes[1]]), units[_axes[1]])
+        ),
+        "Pixels must be square, please regrid your image so that they are"
+    );
+    auto subImage = SubImageFactory<T>::createImage(
+        *this->_getImage(), "", *this->_getRegion(), this->_getMask(),
+        this->_getDropDegen(), false, false, this->_getStretch()
+    );
+    const casacore::Int nDim = subImage->ndim();
+    ThrowIf(
+        _axes(0) < 0 || _axes(0) >= nDim
+        || _axes(1) < 0 || _axes(1) >= nDim,
+        "The pixel axes " + casacore::String::toString(_axes) + " are illegal"
+    );
+    ThrowIf(
+        nDim < 2, "The image axes must have at least 2 pixel axes"
+    );
+    shared_ptr<TempImage<T>> outImage(
+        new casacore::TempImage<T>(
+            subImage->shape(), subImage->coordinates()
+        )
+     );
+    _convolve(
+        outImage, *subImage, _type
+    );
+    if (subImage->isMasked()) {
+        TempLattice<Bool> mask(outImage->shape());
+        ImageTask<T>::_copyMask(mask, *subImage);
+        outImage->attachMask(mask);
+    }
+    return this->_prepareOutputImage(*outImage);
+}
+
+template <class T> void Image2DConvolver<T>::_convolve(
+    SPIIT imageOut, const ImageInterface<T>& imageIn,
+    VectorKernel::KernelTypes kernelType
+) const {
+    const auto& inShape = imageIn.shape();
+    const auto& outShape = imageOut->shape();
+    ThrowIf(
+        ! inShape.isEqual(outShape),
+        "Input and output images must have the same shape"
+    );
+    // Generate Kernel Array (height unity)
+    ThrowIf(
+        _targetres && kernelType != casacore::VectorKernel::GAUSSIAN,
+        "targetres can only be true for a Gaussian convolving kernel"
+    );
+    // maybe can remove this comment if I'm smart enough
+    // kernel needs to be type T because ultimately we use ImageConvolver which
+    // requires the kernel and input image to be of the same type. This is
+    // kind of stupid because our kernels are always real-valued, and we use
+    // Fit2D which requires a real-valued kernel, so it seems we could support
+    // complex valued images and real valued kernels if ImageConvolver was
+    // smarter
+    Array<Double> kernel;
+    // initialize to avoid compiler warning, kernelVolume will always be set to
+    // something reasonable below before it is used.
+    Double kernelVolume = -1;
+    std::vector<casacore::Quantity> originalParms{_major, _minor, _pa};
+    if (! _targetres) {
+        kernelVolume = _makeKernel(
+            kernel, kernelType, originalParms, imageIn
+        );
+    }
+    const auto& cSys = imageIn.coordinates();
+    if (_major.getUnit().startsWith("pix")) {
+        auto inc = cSys.increment()[_axes[0]];
+        auto unit = cSys.worldAxisUnits()[_axes[0]];
+        originalParms[0] = _major.getValue()*casacore::Quantity(abs(inc), unit);
+    }
+    if (_minor.getUnit().startsWith("pix")) {
+        auto inc = cSys.increment()[_axes[1]];
+        auto unit = cSys.worldAxisUnits()[_axes[1]];
+        originalParms[1] = _minor.getValue()*casacore::Quantity(abs(inc), unit);
+    }
+    auto kernelParms = originalParms;
+    // Figure out output image restoring beam (if any), output units and scale
+    // factor for convolution kernel array
+    GaussianBeam beamOut;
+    const auto& imageInfo = imageIn.imageInfo();
+    const auto& brightnessUnit = imageIn.units();
+    String brightnessUnitOut;
+    auto iiOut = imageOut->imageInfo();
+    auto logFactors = false;
+    Double factor1 = -1;
+    double pixelArea = 0;
+    auto autoScale = _scale <= 0;
+    if (autoScale) {
+        auto bunitUp = brightnessUnit.getName();
+        bunitUp.upcase();
+        logFactors = bunitUp.contains("/BEAM");
+        if (logFactors) {
+            pixelArea = cSys.directionCoordinate().getPixelArea().getValue(
+                "arcsec*arcsec"
+            );
+            if (! _targetres) {
+                GaussianBeam kernelBeam(kernelParms);
+                factor1 = pixelArea/kernelBeam.getArea("arcsec*arcsec");
+            }
+        }
+    }
+    if (imageInfo.hasMultipleBeams()) {
+        _doMultipleBeams(
+            iiOut, kernelVolume, imageOut, brightnessUnitOut,
+            beamOut, factor1, imageIn, originalParms, kernelParms,
+            kernel, kernelType, logFactors, pixelArea
+        );
+    }
+    else {
+        _doSingleBeam(
+            iiOut, kernelVolume, kernelParms, kernel,
+            brightnessUnitOut, beamOut, imageOut, imageIn,
+            originalParms, kernelType, logFactors, factor1, 
+            pixelArea
+        );
+    }
+    imageOut->setUnits(brightnessUnitOut);
+    imageOut->setImageInfo(iiOut);
+    _logBeamInfo(imageInfo, "Original " + this->_getImage()->name());
+    _logBeamInfo(iiOut, "Output " + this->_getOutname());
+}
+
+template <class T> void Image2DConvolver<T>::_logBeamInfo(
+    const ImageInfo& imageInfo, const String& desc
+) const {
+    ostringstream oss;
+    const auto& beamSet = imageInfo.getBeamSet();
+    if (! imageInfo.hasBeam()) {
+        oss << desc << " has no beam";
+    }
+    else if (imageInfo.hasSingleBeam()) {
+        oss << desc << " resolution " << beamSet.getBeam();
+    }
+    else {
+        oss << desc << " has multiple beams. Min area beam: "
+            << beamSet.getMinAreaBeam() << ". Max area beam: "
+            << beamSet.getMaxAreaBeam() << ". Median area beam "
+            << beamSet.getMedianAreaBeam();
+    }
+    auto msg = oss.str();
+    LogOrigin lor(getClass(), __func__);
+    this->addHistory(lor, msg);
+    _log(msg, LogIO::NORMAL);
+}
+
+template <class T> void Image2DConvolver<T>::_log(
+    const String& msg, LogIO::Command priority
+) const {
+    if (! _suppressWarnings) {
+        *this->_getLog() << priority << msg << LogIO::POST;
+    }
+}
+
+template <class T> void Image2DConvolver<T>::_doSingleBeam(
+    ImageInfo& iiOut, Double& kernelVolume, vector<Quantity>& kernelParms,
+    Array<Double>& kernel, String& brightnessUnitOut, GaussianBeam& beamOut,
+    SPIIT imageOut, const ImageInterface<T>& imageIn,
+    const vector<Quantity>& originalParms, VectorKernel::KernelTypes kernelType,
+    Bool logFactors, Double factor1, Double pixelArea
+) const {
+    GaussianBeam inputBeam = imageIn.imageInfo().restoringBeam();
+    if (_targetres) {
+        kernelParms = _getConvolvingBeamForTargetResolution(
+            originalParms, inputBeam
+        );
+        if (! _suppressWarnings) {
+            *this->_getLog() << LogOrigin("Image2DConvolver<T>", __func__);
+            ostringstream oss;
+            oss << "Convolving image that has a beam of "
+                << inputBeam << " with a Gaussian of "
+                << GaussianBeam(kernelParms) << " to reach a target resolution of "
+                << GaussianBeam(originalParms);
+            _log(oss.str(), LogIO::NORMAL);
+        }
+        kernelVolume = _makeKernel(
+            kernel, kernelType, kernelParms, imageIn
+        );
+    }
+    const CoordinateSystem& cSys = imageIn.coordinates();
+    auto scaleFactor = _dealWithRestoringBeam(
+        brightnessUnitOut, beamOut, kernel, kernelVolume,
+        kernelType, kernelParms, cSys, inputBeam,
+        imageIn.units(), true
+    );
+    ostringstream oss;
+    if (! _suppressWarnings) {
+        oss << "Scaling pixel values by ";
+    }
+    if (logFactors) {
+        if (_targetres) {
+            GaussianBeam kernelBeam(kernelParms);
+            factor1 = pixelArea/kernelBeam.getArea("arcsec*arcsec");
+        }
+        Double factor2 = beamOut.getArea("arcsec*arcsec")/inputBeam.getArea("arcsec*arcsec");
+        if (! _suppressWarnings) {
+            oss << "inverse of area of convolution kernel in pixels (" << factor1
+                << ") times the ratio of the beam areas (" << factor2 << ") = ";
+        }
+    }
+    if (! _suppressWarnings) {
+        oss << scaleFactor;
+        _log(oss.str(), LogIO::NORMAL);
+    }
+    if (_targetres && near(beamOut.getMajor(), beamOut.getMinor(), 1e-7)) {
+        // circular beam should have same PA as given by user if
+        // targetres
+        beamOut.setPA(originalParms[2]);
+    }
+    // Convolve.  We have already scaled the convolution kernel (with some
+    // trickery cleverer than what ImageConvolver can do) so no more scaling
+    ImageConvolver<T> aic;
+    Array<T> modKernel(kernel.shape());
+    casacore::convertArray(modKernel, scaleFactor*kernel);
+    aic.convolve(
+        *this->_getLog(), *imageOut, imageIn, modKernel,
+        ImageConvolver<T>::NONE, 1.0, true
+    );
+    // Overwrite some bits and pieces in the output image to do with the
+    // restoring beam  and image units
+    casacore::Bool holdsOneSkyAxis;
+    casacore::Bool hasSky = CoordinateUtil::holdsSky (holdsOneSkyAxis, cSys, _axes.asVector());
+    if (hasSky && ! beamOut.isNull()) {
+        iiOut.setRestoringBeam(beamOut);
+    }
+    else {
+        // If one of the axes is in the sky plane, we must
+        // delete the restoring beam as it is no longer meaningful
+        if (holdsOneSkyAxis) {
+            if (! _suppressWarnings) {
+                oss.str("");
+                oss << "Because you convolved just one of the sky axes" << endl;
+                oss << "The output image does not have a valid spatial restoring beam";
+                _log(oss.str(), LogIO::WARN);
+            }
+            iiOut.removeRestoringBeam();
+        }
+    }
+}
+
+template <class T> void Image2DConvolver<T>::_doMultipleBeams(
+    ImageInfo& iiOut, Double& kernelVolume, SPIIT imageOut,
+    String& brightnessUnitOut, GaussianBeam& beamOut, Double factor1,
+    const ImageInterface<T>& imageIn, const vector<Quantity>& originalParms,
+    vector<Quantity>& kernelParms, Array<Double>& kernel,
+    VectorKernel::KernelTypes kernelType, Bool logFactors, Double pixelArea
+) const {
+    ImageMetaData<T> md(imageOut);
+    auto nChan = md.nChannels();
+    auto nPol = md.nStokes();
+    // initialize all beams to be null
+    iiOut.setAllBeams(nChan, nPol, casacore::GaussianBeam());
+    const auto& cSys = imageIn.coordinates();
+    auto specAxis = cSys.spectralAxisNumber();
+    auto polAxis = cSys.polarizationAxisNumber();
+    casacore::IPosition start(imageIn.ndim(), 0);
+    auto end = imageIn.shape();
+    if (nChan > 0) {
+        end[specAxis] = 1;
+    }
+    if (nPol > 0) {
+        end[polAxis] = 1;
+    }
+    casacore::Int channel = -1;
+    casacore::Int polarization = -1;
+    if (_targetres) {
+        iiOut.removeRestoringBeam();
+        iiOut.setRestoringBeam(casacore::GaussianBeam(kernelParms));
+    }
+    casacore::uInt count = (nChan > 0 && nPol > 0)
+        ? nChan * nPol
+        : nChan > 0
+          ? nChan
+          : nPol;
+
+    if (_progressMonitor) {
+        // assume the total number of steps for the whole moments calculation
+        // is twice as the number of steps for the beam convolution
+        _progressMonitor->init(count * 2);
+
+        // set total number of steps for the beam convolution
+        _totalSteps = count;
+    }
+
+    for (casacore::uInt i=0; i<count; ++i) {
+        if (_stop) { // cancel calculations
+            break;
+        }
+
+        if (_progressMonitor) {
+            _progressMonitor->nstepsDone(i);
+        }
+
+        if (nChan > 0) {
+            channel = i % nChan;
+            start[specAxis] = channel;
+        }
+        if (nPol > 0) {
+            polarization = nChan > 1
+                ? (i - channel) % nChan
+                : i;
+            start[polAxis] = polarization;
+        }
+        casacore::Slicer slice(start, end);
+        casacore::SubImage<T> subImage(imageIn, slice);
+        casacore::CoordinateSystem subCsys = subImage.coordinates();
+        if (subCsys.hasSpectralAxis()) {
+            auto subRefPix = subCsys.referencePixel();
+            subRefPix[specAxis] = 0;
+            subCsys.setReferencePixel(subRefPix);
+        }
+        auto inputBeam
+            = imageIn.imageInfo().restoringBeam(channel, polarization);
+        auto doConvolve = true;
+        if (_targetres) {
+            *this->_getLog() << LogIO::NORMAL;
+            if (channel >= 0) {
+                *this->_getLog() << "Channel " << channel << " of " << nChan;
+                if (polarization >= 0) {
+                    *this->_getLog() << ", ";
+                }
+            }
+            if (polarization >= 0) {
+                *this->_getLog() << "Polarization " << polarization
+                    << " of " << nPol;
+            }
+            *this->_getLog() << " ";
+            if (
+                near(
+                    inputBeam, GaussianBeam(originalParms), 1e-5,
+                    casacore::Quantity(1e-2, "arcsec")
+                )
+            ) {
+                doConvolve = false;
+                *this->_getLog() << LogIO::NORMAL
+                    << " Input beam is already near target resolution so this "
+                    << "plane will not be convolved" << LogIO::POST;
+            }
+            else {
+                kernelParms = _getConvolvingBeamForTargetResolution(
+                    originalParms, inputBeam
+                );
+                kernelVolume = _makeKernel(
+                    kernel, kernelType, kernelParms, imageIn
+                );
+                *this->_getLog() << ": Convolving image which has a beam of "
+                    << inputBeam << " with a Gaussian of "
+                    << GaussianBeam(kernelParms) << " to reach a target "
+                    << "resolution of " << GaussianBeam(originalParms)
+                    << LogIO::POST;
+            }
+        }
+        casacore::TempImage<T> subImageOut(
+            subImage.shape(), subImage.coordinates()
+        );
+        if (doConvolve) {
+            auto scaleFactor = _dealWithRestoringBeam(
+                brightnessUnitOut, beamOut, kernel, kernelVolume, kernelType,
+                kernelParms, subCsys, inputBeam, imageIn.units(), i == 0
+            );
+            {
+                *this->_getLog() << LogIO::NORMAL << "Scaling pixel values by ";
+                if (logFactors) {
+                    if (_targetres) {
+                        casacore::GaussianBeam kernelBeam(kernelParms);
+                        factor1 = pixelArea/kernelBeam.getArea("arcsec*arcsec");
+                    }
+                    auto factor2 = beamOut.getArea("arcsec*arcsec")
+                        /inputBeam.getArea("arcsec*arcsec");
+                    *this->_getLog() << "inverse of area of convolution kernel "
+                        << "in pixels (" << factor1 << ") times the ratio of "
+                        << "the beam areas (" << factor2 << ") = ";
+                }
+                *this->_getLog() << scaleFactor << " for ";
+                if (channel >= 0) {
+                    *this->_getLog() << "channel number " << channel;
+                    if (polarization >= 0) {
+                        *this->_getLog() << " and ";
+                    }
+                }
+                if (polarization >= 0) {
+                    *this->_getLog() << "polarization number " << polarization;
+                }
+                *this->_getLog() << casacore::LogIO::POST;
+            }
+            if (
+                _targetres && near(beamOut.getMajor(), beamOut.getMinor(), 1e-7)
+            ) {
+                // circular beam should have same PA as given by user if
+                // targetres
+                beamOut.setPA(originalParms[2]);
+            }
+            Array<T> modKernel(kernel.shape());
+            casacore::convertArray(modKernel, scaleFactor*kernel);
+            ImageConvolver<T> aic;
+            aic.convolve(
+                *this->_getLog(), subImageOut, subImage, modKernel,
+                ImageConvolver<T>::NONE, 1.0, true
+            );
+
+            // _doImageConvolver(subImageOut, subImage, scaleFactor*kernel);
+        }
+        else {
+            brightnessUnitOut = imageIn.units().getName();
+            beamOut = inputBeam;
+            subImageOut.put(subImage.get());
+        }
+        {
+            auto doMask = imageOut->isMasked() && imageOut->hasPixelMask();
+            Lattice<Bool>* pMaskOut = 0;
+            if (doMask) {
+                pMaskOut = &imageOut->pixelMask();
+                if (! pMaskOut->isWritable()) {
+                    doMask = false;
+                }
+            }
+            auto cursorShape = subImageOut.niceCursorShape();
+            auto outPos = start;
+            LatticeStepper stepper(
+                subImageOut.shape(), cursorShape,
+                casacore::LatticeStepper::RESIZE
+            );
+            RO_MaskedLatticeIterator<T> iter(subImageOut, stepper);
+            for (iter.reset(); !iter.atEnd(); iter++) {
+                casacore::IPosition cursorShape = iter.cursorShape();
+                imageOut->putSlice(iter.cursor(), outPos);
+                if (doMask) {
+                    pMaskOut->putSlice(iter.getMask(), outPos);
+                }
+                outPos = outPos + cursorShape;
+            }
+        }
+        if (! _targetres) {
+            iiOut.setBeam(
+                channel, polarization, beamOut
+            );
+        }
+    }
+}
+
+template <class T> Double Image2DConvolver<T>::_makeKernel(
+    casacore::Array<Double>& kernelArray,
+    casacore::VectorKernel::KernelTypes kernelType,
+    const std::vector<casacore::Quantity>& parameters,
+    const casacore::ImageInterface<T>& imageIn
+) const {
+
+// Check number of parameters
+
+   _checkKernelParameters(kernelType, parameters);
+
+// Convert kernel widths to pixels from world.  Demands major and minor
+// both in pixels or both in world, else exception
+
+   casacore::Vector<casacore::Double> dParameters;
+   const casacore::CoordinateSystem cSys = imageIn.coordinates();
+
+// Use the reference value for the shape conversion direction
+
+   casacore::Vector<casacore::Quantity> wParameters(5);
+   for (casacore::uInt i=0; i<3; i++) {
+      wParameters(i+2) = parameters[i];
+   }
+//
+   const casacore::Vector<casacore::Double> refVal = cSys.referenceValue();
+   const casacore::Vector<casacore::String> units = cSys.worldAxisUnits();
+   casacore::Int wAxis = cSys.pixelAxisToWorldAxis(_axes(0));
+   wParameters(0) = casacore::Quantity(refVal(wAxis), units(wAxis));
+   wAxis = cSys.pixelAxisToWorldAxis(_axes(1));
+   wParameters(1) = casacore::Quantity(refVal(wAxis), units(wAxis));
+   SkyComponentFactory::worldWidthsToPixel(
+       dParameters, wParameters, cSys, _axes, false
+   );
+
+// Create n-Dim kernel array shape
+
+   auto kernelShape = _shapeOfKernel(kernelType, dParameters, imageIn.ndim());
+
+// Create kernel array. We will fill the n-Dim array (shape non-unity
+// only for pixelAxes) through its 2D casacore::Matrix incarnation. Aren't we clever.
+   kernelArray = 0;
+   kernelArray.resize(kernelShape);
+   auto kernelArray2 = kernelArray.nonDegenerate(_axes);
+   auto kernelMatrix = static_cast<casacore::Matrix<Double>>(kernelArray2);
+
+// Fill kernel casacore::Matrix with functional (height unity)
+
+   return _fillKernel (kernelMatrix, kernelType, kernelShape, dParameters);
+}
+
+template <class T> Double Image2DConvolver<T>::_dealWithRestoringBeam(
+    String& brightnessUnitOut,
+    GaussianBeam& beamOut, const casacore::Array<Double>& kernelArray,
+    Double kernelVolume, const casacore::VectorKernel::KernelTypes,
+    const casacore::Vector<casacore::Quantity>& parameters,
+    const casacore::CoordinateSystem& cSys,
+    const casacore::GaussianBeam& beamIn,
+    const casacore::Unit& brightnessUnitIn, casacore::Bool emitMessage
+) const {
+    *this->_getLog() << LogOrigin(CLASS_NAME, __func__);
+    // Find out if convolution axes hold the sky.  Scaling from
+    // Jy/beam and Jy/pixel only really makes sense if this is true
+    casacore::Bool holdsOneSkyAxis;
+    auto hasSky = casacore::CoordinateUtil::holdsSky(
+        holdsOneSkyAxis, cSys, _axes.asVector()
+    );
+    if (hasSky) {
+        const casacore::DirectionCoordinate dc = cSys.directionCoordinate();
+        auto inc = dc.increment();
+        auto unit = dc.worldAxisUnits();
+        casacore::Quantity x(inc[0], unit[0]);
+        casacore::Quantity y(inc[1], unit[1]);
+        auto diag = sqrt(x*x + y*y);
+        auto minAx = parameters[1];
+        if (minAx.getUnit().startsWith("pix")) {
+            minAx.setValue(minAx.getValue()*x.getValue());
+            minAx.setUnit(x.getUnit());
+        }
+        if (minAx < diag) {
+            diag.convert(minAx.getFullUnit());
+            if (! _suppressWarnings) {
+                ostringstream oss;
+                oss << "Convolving kernel has minor axis " << minAx << " which "
+                    << "is less than the pixel diagonal length of " << diag
+                    << ". Thus, the kernel is poorly sampled, and so the "
+                    << "output of this application may not be what you expect. "
+                    << "You should consider increasing the kernel size or "
+                    << "regridding the image to a smaller pixel size";
+                _log(oss.str(), LogIO::WARN);
+            }
+        }
+        else if (
+            beamIn.getMinor() < diag
+            && beamIn != casacore::GaussianBeam::NULL_BEAM
+        ) {
+            diag.convert(beamIn.getMinor().getFullUnit());
+            if (! _suppressWarnings) {
+                ostringstream oss;
+                oss << "Input beam has minor axis "
+                    << beamIn.getMinor() << " which is less than the pixel "
+                    << "diagonal length of " << diag << ". Thus, the beam is "
+                    << "poorly sampled, and so the output of this application "
+                    << "may not be what you expect. You should consider "
+                    << "regridding the image to a smaller pixel size.";
+                _log(oss.str(), LogIO::WARN);
+            }
+        }
+    }
+    if (emitMessage && ! _suppressWarnings) {
+        ostringstream oss;
+        oss << "You are " << (hasSky ? "" : " not ") << "convolving the sky";
+        _log(oss.str(), LogIO::NORMAL);
+    }
+    beamOut = casacore::GaussianBeam();
+    auto bUnitIn = upcase(brightnessUnitIn.getName());
+    const auto& refPix = cSys.referencePixel();
+    Double scaleFactor = 1;
+    brightnessUnitOut = brightnessUnitIn.getName();
+    auto autoScale = _scale <= 0;
+    if (hasSky && bUnitIn.contains("/PIXEL")) {
+        // Easy case.  Peak of convolution kernel must be unity
+        // and output units are Jy/beam.  All other cases require
+        // numerical convolution of beams
+        brightnessUnitOut = "Jy/beam";
+        // Exception already generated if only
+        // one of major and minor in pixel units
+        auto majAx = parameters(0);
+        auto minAx = parameters(1);
+        if (majAx.getFullUnit().getName() == "pix") {
+            casacore::Vector<casacore::Double> pixelParameters(5);
+            pixelParameters(0) = refPix(_axes(0));
+            pixelParameters(1) = refPix(_axes(1));
+            pixelParameters(2) = parameters(0).getValue();
+            pixelParameters(3) = parameters(1).getValue();
+            pixelParameters(4) = parameters(2).getValue(casacore::Unit("rad"));
+            casacore::GaussianBeam worldParameters;
+            SkyComponentFactory::pixelWidthsToWorld(
+                worldParameters, pixelParameters,
+                cSys, _axes, false
+            );
+            majAx = worldParameters.getMajor();
+            minAx = worldParameters.getMinor();
+        }
+        beamOut = casacore::GaussianBeam(majAx, minAx, parameters(2));
+        // casacore::Input p.a. is positive N->E
+        if (! autoScale) {
+            scaleFactor = _scale;
+            _log(
+                "Autoscaling is recommended for Jy/pixel convolution",
+                LogIO::WARN
+            );
+        }
+    }
+    else {
+        // Is there an input restoring beam and are we convolving the sky to
+        // which it pertains?  If not, all we can do is use user scaling or
+        // normalize the convolution kernel to unit volume.  There is no point
+        // to convolving the input beam either as it pertains only to the sky
+        if (hasSky && ! beamIn.isNull()) {
+            // Convert restoring beam parameters to pixels.
+            // Output pa is pos +x -> +y in pixel frame.
+            casacore::Vector<casacore::Quantity> wParameters(5);
+            const auto refVal = cSys.referenceValue();
+            const auto units = cSys.worldAxisUnits();
+            auto wAxis = cSys.pixelAxisToWorldAxis(_axes(0));
+            wParameters(0) = casacore::Quantity(refVal(wAxis), units(wAxis));
+            wAxis = cSys.pixelAxisToWorldAxis(_axes(1));
+            wParameters(1) = casacore::Quantity(refVal(wAxis), units(wAxis));
+            wParameters(2) = beamIn.getMajor();
+            wParameters(3) = beamIn.getMinor();
+            wParameters(4) = beamIn.getPA(true);
+            casacore::Vector<casacore::Double> dParameters;
+            SkyComponentFactory::worldWidthsToPixel(
+                dParameters, wParameters, cSys, _axes, false
+            );
+            // Create 2-D beam array shape
+            // casacore::IPosition dummyAxes(2, 0, 1);
+            auto beamShape = _shapeOfKernel(
+                casacore::VectorKernel::GAUSSIAN, dParameters, 2
+            );
+
+            // Create beam casacore::Matrix and fill with height unity
+   
+            casacore::Matrix<Double> beamMatrixIn(beamShape(0), beamShape(1));
+            _fillKernel(
+                beamMatrixIn, casacore::VectorKernel::GAUSSIAN, beamShape,
+                dParameters
+            );
+            auto shape = beamMatrixIn.shape();
+            // Get 2-D version of convolution kenrel
+            auto kernelArray2 = kernelArray.nonDegenerate(_axes);
+            auto kernelMatrix
+                = static_cast<casacore::Matrix<Double>>(kernelArray2);
+            // Convolve input restoring beam array by convolution kernel array
+            casacore::Matrix<Double> beamMatrixOut;
+            casacore::Convolver<Double> conv(beamMatrixIn, kernelMatrix.shape());
+            conv.linearConv(beamMatrixOut, kernelMatrix);
+            // Scale kernel
+            auto maxValOut = max(beamMatrixOut);
+            scaleFactor = autoScale ? 1/maxValOut : _scale;
+            Fit2D fitter(*this->_getLog());
+            const casacore::uInt n = beamMatrixOut.shape()(0);
+            auto bParameters
+                = fitter.estimate(casacore::Fit2D::GAUSSIAN, beamMatrixOut);
+            casacore::Vector<casacore::Bool> bParameterMask(
+                bParameters.nelements(), true
+            );
+            bParameters(1) = (n-1)/2;          // x centre
+            bParameters(2) = bParameters(1);    // y centre
+            // Set range so we don't include too many pixels
+            // in fit which will make it very slow
+            fitter.addModel(
+                casacore::Fit2D::GAUSSIAN, bParameters, bParameterMask
+            );
+            casacore::Array<Double> sigma;
+            fitter.setIncludeRange(maxValOut/10.0, maxValOut+0.1);
+            auto error = fitter.fit(beamMatrixOut, sigma);
+            ThrowIf(
+                error == casacore::Fit2D::NOCONVERGE
+                || error == casacore::Fit2D::FAILED
+                || error == casacore::Fit2D::NOGOOD,
+                "Failed to fit the output beam"
+            );
+            auto bSolution = fitter.availableSolution();
+            // Convert to world units.
+            casacore::Vector<casacore::Double> pixelParameters(5);
+            pixelParameters(0) = refPix(_axes(0));
+            pixelParameters(1) = refPix(_axes(1));
+            pixelParameters(2) = bSolution(3);
+            pixelParameters(3) = bSolution(4);
+            pixelParameters(4) = bSolution(5);
+            SkyComponentFactory::pixelWidthsToWorld(
+                beamOut, pixelParameters, cSys, _axes, false
+            );
+            if (
+                ! brightnessUnitIn.getName().contains(
+                    casacore::Regex(Regex::makeCaseInsensitive("beam"))
+                )
+            ) {
+                scaleFactor *= beamIn.getArea("arcsec2")
+                    /beamOut.getArea("arcsec2");
+            }
+        }
+        else {
+            if (autoScale) {
+                // Conserve flux is the best we can do
+                scaleFactor = 1/kernelVolume;
+            }
+            else {
+                scaleFactor = _scale;
+            }
+        }
+    }
+    // Put beam position angle into range
+    // +/- 180 in case it has eluded us so far
+    if (! beamOut.isNull()) {
+        casacore::MVAngle pa(
+            beamOut.getPA(true).getValue(casacore::Unit("rad"))
+        );
+        pa();
+        beamOut = casacore::GaussianBeam(
+            beamOut.getMajor(), beamOut.getMinor(),
+            casacore::Quantity(pa.degree(), casacore::Unit("deg"))
+        );
+    }
+    return scaleFactor;
+}
+
+template <class T> void Image2DConvolver<T>::_checkKernelParameters(
+    casacore::VectorKernel::KernelTypes kernelType,
+    const casacore::Vector<casacore::Quantity >& parameters
+) const {
+    if (kernelType==casacore::VectorKernel::BOXCAR) {
+        ThrowCc("Boxcar kernel not yet implemented");
+        ThrowIf(
+            parameters.nelements() != 3,
+            "Boxcar kernels require 3 parameters"
+        );
+    }
+    else if (kernelType==casacore::VectorKernel::GAUSSIAN) {
+        ThrowIf(
+            parameters.nelements() != 3,
+            "Gaussian kernels require exactly 3 parameters"
+        );
+    }
+    else {
+        ThrowCc(
+            "The kernel type " + casacore::VectorKernel::fromKernelType(kernelType) + " is not supported"
+        );
+    }
+}
+
+template <class T> casacore::IPosition Image2DConvolver<T>::_shapeOfKernel(
+    const casacore::VectorKernel::KernelTypes kernelType,
+    const casacore::Vector<casacore::Double>& parameters,
+    const casacore::uInt ndim
+) const {
+//
+// Work out how big the array holding the kernel should be.
+// Simplest algorithm possible. Shape is presently square.
+//
+
+// Find 2D shape
+
+   casacore::uInt n;
+   if (kernelType==casacore::VectorKernel::GAUSSIAN) {
+      casacore::uInt n1 = _sizeOfGaussian (parameters(0), 5.0);
+      casacore::uInt n2 = _sizeOfGaussian (parameters(1), 5.0);
+      n = max(n1,n2);
+      if (n%2==0) n++;                                     // Make shape odd so centres well
+   } else if (kernelType==casacore::VectorKernel::BOXCAR) {
+      n = 2 * casacore::Int(max(parameters(0), parameters(1))+0.5);
+      if (n%2==0) n++;                                     // Make shape odd so centres well
+   } else {
+     throw(casacore::AipsError("Unrecognized kernel type"));        // Earlier checking should prevent this
+   }
+
+// Now find the shape for the image and slot the 2D shape in
+// in the correct axis locations
+
+   casacore::IPosition shape(ndim,1);
+   shape(_axes(0)) = n;
+   shape(_axes(1)) = n;
+   return shape;
+}
+   
+template <class T>
+uInt Image2DConvolver<T>::_sizeOfGaussian(
+    const casacore::Double width, const casacore::Double nSigma
+) const {
+// +/- 5sigma is a volume error of less than 6e-5%
+
+   casacore::Double sigma = width / sqrt(casacore::Double(8.0) * C::ln2);
+   return  (casacore::Int(nSigma*sigma + 0.5) + 1) * 2;
+}
+
+template <class T> Double Image2DConvolver<T>::_fillKernel(
+    casacore::Matrix<Double>& kernelMatrix,
+    casacore::VectorKernel::KernelTypes kernelType,
+    const casacore::IPosition& kernelShape,
+    const casacore::Vector<casacore::Double>& parameters
+) const {
+
+// Centre functional in array (shape is odd)
+
+   auto xCentre = Double((kernelShape[_axes[0]] - 1)/2.0);
+   auto yCentre = Double((kernelShape[_axes[1]] - 1)/2.0);
+   Double height = 1;
+
+// Create functional.  We only have gaussian2d functionals
+// at this point.  Later the filling code can be moved out
+// of the if statement
+
+   Double maxValKernel;
+   Double volumeKernel = 0;
+   auto pa = parameters[2];
+   auto ratio = parameters[1]/parameters[0];
+   auto major = parameters[0];
+   if (kernelType==casacore::VectorKernel::GAUSSIAN) {
+       _fillGaussian(
+           maxValKernel, volumeKernel, kernelMatrix, height,
+           xCentre, yCentre, major, ratio, pa
+       );
+   }
+   else if (kernelType==casacore::VectorKernel::BOXCAR) {
+       ThrowCc("Boxcar convolution not supported");
+   }
+   else {
+       // Earlier checking should prevent this
+       ThrowCc("Unrecognized kernel type");
+   }
+   return volumeKernel;
+}         
+
+template <class T> void Image2DConvolver<T>::_fillGaussian(
+    Double& maxVal, Double& volume, casacore::Matrix<Double>& pixels,
+    Double height, Double xCentre, Double yCentre, Double majorAxis,
+    Double ratio, Double positionAngle
+) const {
+// 
+// pa positive in +x ->+y pixel coordinate frame
+//
+   casacore::uInt n1 = pixels.shape()(0);
+   casacore::uInt n2 = pixels.shape()(1);
+   AlwaysAssert(n1==n2,casacore::AipsError);
+   positionAngle += C::pi_2;        // +y -> -x
+   casacore::Gaussian2D<Double> g2d(height, xCentre, yCentre, majorAxis,
+               ratio, positionAngle);
+   maxVal = -1.0e30;
+   volume = 0.0;
+   casacore::Vector<Double> pos(2);
+   for (casacore::uInt j=0; j<n1; ++j) {
+      pos[1] = j;
+      for (casacore::uInt i=0; i<n1; ++i) {
+         pos[0] = i;
+         Double val = g2d(pos);
+         pixels(i,j) = val;
+         maxVal = max(val, maxVal);
+         volume += val;
+      }
+   } 
+}
+
+template <class T> void Image2DConvolver<T>::stopCalculation() {
+    _stop = true;
+}
+
+}

--- a/modified_files/ImageMoments.h
+++ b/modified_files/ImageMoments.h
@@ -1,0 +1,399 @@
+//# ImageMoments.h: generate moments from images
+//# Copyright (C) 1996,1997,1998,1999,2000,2001,2002,2003
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: ImageMoments.h 20299 2008-04-03 05:56:44Z gervandiepen $
+
+#ifndef IMAGES_IMAGEMOMENTS_H
+#define IMAGES_IMAGEMOMENTS_H
+
+#include <imageanalysis/ImageAnalysis/MomentsBase.h>
+#include <imageanalysis/ImageAnalysis/ImageMomentsProgress.h>
+#include <imageanalysis/ImageAnalysis/Image2DConvolver.h>
+#include <imageanalysis/ImageTypedefs.h>
+
+namespace casacore{
+
+template <class T> class MaskedLattice;
+}
+
+namespace casa {
+
+class ImageMomentsProgressMonitor;
+
+// <summary>
+// This class generates moments from an image.
+// </summary>
+
+// <use visibility=export>
+
+// <reviewed reviewer="" date="yyyy/mm/dd" tests="" demos="">
+// </reviewed>
+
+// <prerequisite>
+//   <li> <linkto class="casacore::ImageInterface">casacore::ImageInterface</linkto>
+//   <li> <linkto class="MomentsBase">MomentsBase</linkto>
+//   <li> <linkto class="casacore::LatticeApply">casacore::LatticeApply</linkto>   
+//   <li> <linkto class="MomentCalcBase">MomentCalcBase</linkto>
+// </prerequisite>
+
+// <etymology>
+//   This class computes moments from images
+// </etymology>
+
+// <synopsis>
+//  The primary goal of this class is to help spectral-line astronomers analyze 
+//  their multi-dimensional images by generating moments of a specified axis.
+//  The word "moment" is used loosely here.  It refers to collapsing an axis
+//  to one pixel and putting the value of that pixel (for all of the other 
+//  non-collapsed axes) to something computed from the data values along
+//  the moment axis.  For example, take an RA-DEC-Velocity cube, collapse
+//  the velocity axis by computing the mean intensity at each RA-DEC
+//  pixel.  This class offers many different moments and a variety of
+//  interactive and automatic ways to compute them.
+//
+//  This class only accepts images of type <src>casacore::Float</src> and <src>casacore::Double</src>.
+//  This restriction is because of the plotting capabilities which are a
+//  bit awkward for other types.
+//
+//  This class makes a distinction between a "moment" and a "method". This
+//  boundary is a little blurred, but it claims to refer to the distinction 
+//  of what you are computing, as to how the pixels that were included in the 
+//  computation were selected.  For example,  a "moment" would be the average value 
+//  of some pixels.  A method for selecting those pixels would be a simple range 
+//  specifying  a range for which pixels should be included.
+//
+//  The default state of this class is to do nothing.  If you specify an image via
+//  the <src>setImage</src> function then invoking the <src>createMoments</src>
+//  function will cause it to compute the integrated itensity along the 
+//  spectral axis of the image (if it can find one).  You can change the 
+//  computational state of the class from this basic form via the remaining
+//  <src>set</src> functions.  You can call any number of these functions to 
+//  suit your needs.
+//
+//  Because there are a wide variety of methods available, if you specify an
+//  invalid combination, a table showing the available methods is listed. It
+//  is reproduced below for convenience.  
+//
+//  The basic method is to just compute moments directly from the pixel intensities.  
+//  This can be modified by applying pixel intensity inclusion or exclusion ranges.  
+//  You can then also smooth the image and compute a mask based on the inclusion or 
+//  exclusion ranges applied to the smoothed image.  This mask is then applied to 
+//  the unsmoothed data for moment computation.
+//
+//  The window method does no pixel intensity range selection.  Instead a spectral
+//  window is found (hopefully surrounding the spectral line feature) and only the 
+//  pixels in that window are used for computation.  This window can be found from the 
+//  smoothed or unsmoothed data.  The moments are always computed from the unsmoothed 
+//  data.  For each spectrum, the window can be found interactively or automatically.
+//  There are two interactive methods.  Either you just mark the window with the
+//  cursor, or you interactively fit a Gaussian to the profile and the +/- 3-sigma
+//  window is returned.  There are two automatic methods.  Either Bosma's converging
+//  mean algorithm is used, or an automatically  fit Gaussian +/- 3-sigma window
+//  is returned.
+//
+//  The fitting method fits Gaussians to spectral features either automatically
+//  or interactively.  The moments are then computed from the Gaussian fits
+//  (not the data themselves).
+//
+//  When an output image is created, it will have N-1 axes, where the input image
+//  has N axes.  In the output image, the physical axis corresponding to the moment
+//  axis will have been removed, but the coordinate information will be retained 
+//  for future coordinate transformations. For example, if you have a RA-DEC-VELOCITY 
+//  image and you collapsed axis 2 (the DEC axis) the output images would be 
+//  RA-VELOCITY with the coordinate information retained for the DEC axis so that 
+//  the coupled nature of RA/DEC coordinates is preserved.    
+//
+//  Output images are created with an all true (good) mask.  If, for a given
+//  pixel, the moment calculation fails, then the mask is set to F.
+//
+//  When making plots, the order in which the spectra are  displayed is determined
+//  by the tiling sequence of the image (for optimum speed of access).  
+//
+//
+// <srcblock>
+//                   Allowed Methods
+//                   ---------------
+//
+//   casacore::Smooth    Window      Fit   in/exclude   Interactive 
+//   -----------------------------------------------------
+//     N          N         N        N            N       
+//     Y/N        N         N        Y            N       
+// 
+//     Y/N        Y         N        N            Y       
+//     Y/N        Y         N        N            N       
+//     Y/N        Y         Y        N            Y/N     
+//
+//     N          N         Y        N            Y/N     
+//   ----------------------------------------------------
+// </srcblock>
+//
+// <note role=caution>
+// Note that the <src>MEDIAN_COORDINATE</src> moment is not very robust.
+// It is very useful for generating quickly a velocity field in a way
+// that is not sensitive to noise.    However, it will only give sensible
+// results under certain conditions.   It treats the spectrum as a
+// probability distribution, generates the cumulative distribution for
+// the selected pixels (via an <src>include</src> or <src>exclude</src>
+// pixel range, and finds the (interpolated) coordinate coresponding to 
+// the 50% value.  The generation of the cumulative distribution and the
+// finding of the 50% level really only makes sense if the cumulative
+// distribution is monotonically increasing.  This essentially means only
+// selecting pixels which are positive or negative.  For this reason, this
+// moment type is *only* supported with the basic method (i.e. no smoothing,
+// no windowing, no fitting) with a pixel selection range that is either
+// all positive, or all negative.
+// </note>
+//
+// <note role=tip>
+// If you ignore return error statuses from the functions that set the
+// state of the class, the internal status of the class is set to bad.
+// This means it will just  keep on returning error conditions until you
+// explicitly recover the situation.  A message describing the last
+// error condition can be recovered with function errorMessage.
+// </note>
+// </synopsis>
+
+// <example>
+// <srcBlock>
+//// Set state function argument values
+//
+//      casacore::Vector<casacore::Int> moments(2);
+//      moments(0) = ImageMoments<casacore::Float>::AVERAGE;
+//      moments(1) = ImageMoments<casacore::Float>::WEIGHTED_MEAN_COORDINATE;
+//      casacore::Vector<int> methods(2);
+//      methods(0) = ImageMoments<casacore::Float>::WINDOW;
+//      methods(1) = ImageMoments<casacore::Float>::INTERACTIVE;
+//      casacore::Vector<casacore::Int> nxy(2);
+//      nxy(0) = 3;
+//      nxy(1) = 3;
+//
+//// Open paged image
+//     
+//      casacore::PagedImage<casacore::Float> inImage(inName);  
+//
+//// Construct moment helper object
+//
+//      casacore::LogOrigin or("myClass", "myFunction(...)", WHERE);
+//      casacore::LogIO os(or);
+//      ImageMoments<casacore::Float> moment(casacore::SubImage<casacore::Float>(inName), os);
+//
+//// Specify state via control functions
+//
+//      if (!moment.setMoments(moments)) return 1;
+//      if (!moment.setWinFitMethod(methods)) return 1;
+//      if (!moment.setMomentAxis(3)) return 1;
+//      if (!moment.setPlotting("/xs", nxy)) return 1;
+//
+//// Create the moments
+//
+//      if (!moment.createMoments()) return 1;
+// </srcBlock>
+// In this example, we generate two moments (average intensity and intensity
+// weighted mean coordinate -- usually the velocity field) of axis 3 by the 
+// interactive window method.  The interactive plotting is done on the 
+// device called <src>/xs</src> (no longer supported).   We put 9 subplots on each page.  The output 
+// file names are constructed by the class from the input file name plus some 
+// internally generated suffixes.
+// </example>
+
+// <motivation>
+//  This is a fundamental and traditional piece of spectral-line image analysis.
+// </motivation>
+
+// <todo asof="1996/11/26">
+//   <li> more control over histogram of image noise at start (pixel
+//        range and number of bins)
+//   <li> better algorithm for seeing if spectrum is pure noise
+//   <li> Make this class extensible so users could add their own method.
+// </todo>
+ 
+
+template <class T> class ImageMoments : public MomentsBase<T> {
+public:
+
+    // Note that if I don't put MomentCalcBase as a forward declaration
+    // and use instead  "friend class MomentCalcBase<T>"  The gnu compiler
+    // fails with a typedef problem.  But I can't solve it with say
+    // <src>typedef MomentCalcBase<T> gpp_type;</src>  because you can only do a
+    // typedef with an actual type, not a <tt>T</tt> !
+    friend class MomentCalcBase<T>;
+
+    ImageMoments() = delete;
+
+    // Constructor takes an image and a <src>casacore::LogIO</src> object for logging purposes.
+    // You specify whether output images are  automatically overwritten if pre-existing,
+    // or whether an intercative choice dialog widget appears (overWriteOutput=F)
+    // You may also determine whether a progress meter is displayed or not.
+    ImageMoments (
+        const casacore::ImageInterface<T>& image,
+        casacore::LogIO &os,
+        casacore::Bool overWriteOutput=false,
+        casacore::Bool showProgress=true
+    );
+
+    ImageMoments(const ImageMoments<T> &other) = delete;
+
+    // Destructor
+    ~ImageMoments();
+
+    ImageMoments<T> &operator=(const ImageMoments<T> &other) = delete;
+
+    // Set the moment axis (0 relative).  A return value of <src>false</src>
+    // indicates that the axis was not contained in the image. If you don't
+    // call this function, the default state of the class is to set the
+    // moment axis to the spectral axis if it can find one.  Otherwise
+    // an error will result.
+    casacore::Bool setMomentAxis (casacore::Int momentAxis);
+
+    // This function invokes smoothing of the input image.  Give <src>casacore::Int</src>
+    // arrays for the axes (0 relative) to be smoothed and the smoothing kernel
+    // types (use the <src>enum KernelTypes</src>) for each axis.  Give a
+    // <src>casacore::Double</src> array for the widths (full width for BOXCAR and full
+    // width at half maximum for GAUSSIAN) in pixels of the smoothing kernels for
+    // each axis.  For HANNING smoothing, you always get the quarter-half-quarter
+    // kernel (no matter what you might ask for).  A return value of <src>false</src>
+    // indicates that you have given an inconsistent or invalid set of smoothing
+    // parameters.  If you don't call this function the default state of the
+    // class is to do no smoothing.  The kernel types are specified with
+    // the casacore::VectorKernel::KernelTypes enum
+    casacore::Bool setSmoothMethod(
+        const casacore::Vector<casacore::Int>& smoothAxes,
+        const casacore::Vector<casacore::Int>& kernelTypes,
+        const casacore::Vector<casacore::Quantum<casacore::Double> >& kernelWidths
+   );
+
+   casacore::Bool setSmoothMethod(
+       const casacore::Vector<casacore::Int>& smoothAxes,
+       const casacore::Vector<casacore::Int>& kernelTypes,
+       const casacore::Vector<casacore::Double>& kernelWidths
+   );
+
+   // This is the function that does all the computational work.  It should be called
+   // after the <src>set</src> functions.
+   // If the axis being collapsed comes from a coordinate with one axis only,
+   // the axis and its coordinate are physically removed from the output image.  Otherwise,
+   // if <src>removeAxes=true</src> then the output axis is logically removed from the
+   // the output CoordinateSystem.  If <src>removeAxes=false</src> then the axis
+   // is retained with shape=1 and with its original coordinate information (which
+   // is probably meaningless).
+   //
+   // The output vector will hold PagedImages or TempImages (doTemp=true).
+   // If doTemp is true, the outFileName is not used.
+   //
+   // If you create PagedImages, outFileName is the root name for
+   // the output files.  Suffixes will be made up internally to append
+   // to this root.  If you only ask for one moment,
+   // this will be the actual name of the output file.  If you don't set this
+   // variable, the default state of the class is to set the output name root to
+   // the name of the input file.
+   std::vector<std::shared_ptr<casacore::MaskedLattice<T> > >  createMoments(
+       casacore::Bool doTemp, const casacore::String& outFileName,
+       casacore::Bool removeAxes=true
+   );
+
+   // Set a new image.  A return value of <src>false</src> indicates the
+   // image had an invalid type (this class only accepts casacore::Float or casacore::Double images).
+   casacore::Bool setNewImage (const casacore::ImageInterface<T>& image);
+
+   // Get CoordinateSystem
+   const casacore::CoordinateSystem& coordinates() {return _image->coordinates();};
+
+   // Get shape
+   casacore::IPosition getShape() const { return _image->shape(); }
+
+   //Set an ImageMomentsProgressMonitor interested in getting updates on the
+   //progress of the collapse process.
+   void setProgressMonitor(ImageMomentsProgressMonitor* progressMonitor);
+
+   // Stop moments calculations
+   void stopCalculation();
+
+private:
+
+   SPCIIT _image = SPCIIT(nullptr);
+   std::unique_ptr<casa::ImageMomentsProgress> _progressMonitor;
+   std::unique_ptr<casa::Image2DConvolver<T>> _image2dConvolver;
+
+   // casacore::Smooth an image
+   SPIIT _smoothImage();
+
+   // Determine the noise by fitting a Gaussian to a histogram
+   // of the entire image above the 25% levels.  If a plotting
+   // device is set, the user can interact with this process.
+   void _whatIsTheNoise (T& noise, const casacore::ImageInterface<T>& image);
+
+   // Modify from the casacore::LatticeApply<T,U>::lineMultiApply() function
+   void lineMultiApply(
+        casacore::PtrBlock<casacore::MaskedLattice<T>*>& latticeOut,
+        const casacore::MaskedLattice<T>& latticeIn,
+        casacore::LineCollapser<T, T>& collapser, casacore::uInt collapseAxis);
+
+    // Get a suitable chunk shape for moments calculations
+    casacore::IPosition chunkShape(casacore::uInt axis,
+        const casacore::MaskedLattice<T>& latticeIn);
+
+    // Stop moments calculations
+    volatile bool _stop;
+
+    // Number of steps have done for the beam convolution
+    casacore::uInt _stepsForBeamConvolution;
+
+protected:
+   using MomentsBase<T>::os_p;
+   using MomentsBase<T>::showProgress_p;
+   using MomentsBase<T>::momentAxisDefault_p;
+   using MomentsBase<T>::peakSNR_p;
+   using MomentsBase<T>::stdDeviation_p;
+   using MomentsBase<T>::yMin_p;
+   using MomentsBase<T>::yMax_p;
+   using MomentsBase<T>::out_p;
+   using MomentsBase<T>::smoothOut_p;
+   using MomentsBase<T>::goodParameterStatus_p;
+   using MomentsBase<T>::doWindow_p;
+   using MomentsBase<T>::doFit_p;
+   using MomentsBase<T>::doSmooth_p;
+   using MomentsBase<T>::noInclude_p;
+   using MomentsBase<T>::noExclude_p;
+   using MomentsBase<T>::fixedYLimits_p;
+   using MomentsBase<T>::momentAxis_p;
+   using MomentsBase<T>::worldMomentAxis_p;
+   using MomentsBase<T>::kernelTypes_p;
+   using MomentsBase<T>::kernelWidths_p;
+   using MomentsBase<T>::moments_p;
+   using MomentsBase<T>::selectRange_p;
+   using MomentsBase<T>::smoothAxes_p;
+   using MomentsBase<T>::overWriteOutput_p;
+   using MomentsBase<T>::error_p;
+   using MomentsBase<T>::convertToVelocity_p;
+   using MomentsBase<T>::velocityType_p;
+   using MomentsBase<T>::_checkMethod;
+};
+
+}
+
+#ifndef CASACORE_NO_AUTO_TEMPLATES
+#include <imageanalysis/ImageAnalysis/ImageMoments.tcc>
+#endif
+#endif

--- a/modified_files/ImageMoments.tcc
+++ b/modified_files/ImageMoments.tcc
@@ -1,0 +1,829 @@
+//# ImageMoments.cc:  generate moments from an image
+//# Copyright (C) 1995,1996,1997,1998,1999,2000,2001,2002,2003
+//# Associated Universities, Inc. Washington DC, USA.
+//#
+//# This library is free software; you can redistribute it and/or modify it
+//# under the terms of the GNU Library General Public License as published by
+//# the Free Software Foundation; either version 2 of the License, or (at your
+//# option) any later version.
+//#
+//# This library is distributed in the hope that it will be useful, but WITHOUT
+//# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public
+//# License for more details.
+//#
+//# You should have received a copy of the GNU Library General Public License
+//# along with this library; if not, write to the Free Software Foundation,
+//# Inc., 675 Massachusetts Ave, Cambridge, MA 02139, USA.
+//#
+//# Correspondence concerning AIPS++ should be addressed as follows:
+//#        Internet email: aips2-request@nrao.edu.
+//#        Postal address: AIPS++ Project Office
+//#                        National Radio Astronomy Observatory
+//#                        520 Edgemont Road
+//#                        Charlottesville, VA 22903-2475 USA
+//#
+//# $Id: ImageMoments.tcc 20652 2009-07-06 05:04:32Z Malte.Marquarding $
+//   
+
+#include <imageanalysis/ImageAnalysis/ImageMoments.h>
+
+#include <imageanalysis/ImageAnalysis/CasaImageBeamSet.h>
+#include <imageanalysis/ImageAnalysis/ImageHistograms.h>
+#include <imageanalysis/ImageAnalysis/MomentFit.h>
+#include <imageanalysis/ImageAnalysis/MomentClip.h>
+#include <imageanalysis/ImageAnalysis/MomentWindow.h>
+#include <imageanalysis/ImageAnalysis/SepImageConvolver.h>
+
+namespace casa {
+
+template <class T> 
+ImageMoments<T>::ImageMoments (
+    const casacore::ImageInterface<T>& image, casacore::LogIO &os,
+    casacore::Bool overWriteOutput, casacore::Bool showProgressU
+) : MomentsBase<T>(os, overWriteOutput, showProgressU),
+    _progressMonitor(nullptr), _image2dConvolver(nullptr),
+    _stop(false), _stepsForBeamConvolution(0) {
+    setNewImage(image);
+}
+
+template <class T> 
+ImageMoments<T>::~ImageMoments () {}
+
+template <class T> 
+Bool ImageMoments<T>::setNewImage(const casacore::ImageInterface<T>& image) {
+    T *dummy = nullptr;
+    DataType imageType = whatType(dummy);
+
+    ThrowIf(
+        imageType != TpFloat && imageType != TpDouble,
+        "Moments can only be evaluated for Float or Double valued "
+        "images"
+    );
+    // Make a clone of the image
+    _image.reset(image.cloneII());
+    return true;
+}
+
+template <class T>
+Bool ImageMoments<T>::setMomentAxis(const casacore::Int momentAxisU) {
+    if (!goodParameterStatus_p) {
+        throw casacore::AipsError("Internal class status is bad");
+    }
+
+    // reset the number of steps have done for the beam convolution
+    _stepsForBeamConvolution = 0;
+
+    momentAxis_p = momentAxisU;
+    if (momentAxis_p == momentAxisDefault_p) {
+        momentAxis_p = _image->coordinates().spectralAxisNumber();
+        if (momentAxis_p == -1) {
+            goodParameterStatus_p = false;
+            throw casacore::AipsError(
+                    "There is no spectral axis in this image -- specify the axis"
+            );
+        }
+    }
+    else {
+        if (momentAxis_p < 0 || momentAxis_p > casacore::Int(_image->ndim()-1)) {
+            goodParameterStatus_p = false;
+            throw casacore::AipsError("Illegal moment axis; out of range");
+        }
+        if (_image->shape()(momentAxis_p) <= 0) {
+            goodParameterStatus_p = false;
+            throw casacore::AipsError("Illegal moment axis; it has no pixels");
+        }
+    }
+    if (
+        momentAxis_p == _image->coordinates().spectralAxisNumber()
+        && _image->imageInfo().hasMultipleBeams()
+    ) {
+        auto maxBeam = CasaImageBeamSet(_image->imageInfo().getBeamSet()).getCommonBeam();
+        os_p << casacore::LogIO::NORMAL << "The input image has multiple beams so each "
+            << "plane will be convolved to the largest beam size " << maxBeam
+            << " prior to calculating moments" << casacore::LogIO::POST;
+
+        // reset the image 2D convolver
+        _image2dConvolver.reset(new casa::Image2DConvolver<casacore::Float>(_image, nullptr, "", "", false, _progressMonitor.get()));
+
+        // set parameters for the image 2D convolver
+        auto dir_axes = _image->coordinates().directionAxesNumbers();
+        _image2dConvolver->setAxes(std::make_pair(dir_axes[0], dir_axes[1]));
+        _image2dConvolver->setKernel("gaussian", maxBeam.getMajor(), maxBeam.getMinor(), maxBeam.getPA(true));
+        _image2dConvolver->setScale(-1);
+        _image2dConvolver->setTargetRes(true);
+        auto imageCopy = _image2dConvolver->convolve();
+
+        // number of steps have done for the beam convolution
+        _stepsForBeamConvolution = _image2dConvolver->getTotalSteps();
+
+        // replace the input image pointer with the convolved image pointer
+        // and proceed using the convolved image as if it were the input
+        // image
+        if (!_stop) { // check whether moments calculations are cancelled
+            _image = imageCopy;
+        }
+    }
+    worldMomentAxis_p = _image->coordinates().pixelAxisToWorldAxis(momentAxis_p);
+    return true;
+}
+
+template <class T>
+Bool ImageMoments<T>::setSmoothMethod(
+    const casacore::Vector<casacore::Int>& smoothAxesU,
+    const casacore::Vector<casacore::Int>& kernelTypesU,
+    const casacore::Vector<casacore::Quantum<casacore::Double> >& kernelWidthsU
+) {
+    //
+    // Assign the desired smoothing parameters.
+    //
+    if (!goodParameterStatus_p) {
+        error_p = "Internal class status is bad";
+        return false;
+    }
+
+
+    // First check the smoothing axes
+
+    casacore::Int i;
+    if (smoothAxesU.nelements() > 0) {
+        smoothAxes_p = smoothAxesU;
+        for (i=0; i<casacore::Int(smoothAxes_p.nelements()); i++) {
+            if (smoothAxes_p(i) < 0 || smoothAxes_p(i) > casacore::Int(_image->ndim()-1)) {
+                error_p = "Illegal smoothing axis given";
+                goodParameterStatus_p = false;
+                return false;
+            }
+        }
+        doSmooth_p = true;
+    }
+    else {
+        doSmooth_p = false;
+        return true;
+    }
+
+    // Now check the smoothing types
+
+    if (kernelTypesU.nelements() > 0) {
+        kernelTypes_p = kernelTypesU;
+        for (i=0; i<casacore::Int(kernelTypes_p.nelements()); i++) {
+            if (kernelTypes_p(i) < 0 || kernelTypes_p(i) > casacore::VectorKernel::NKERNELS-1) {
+                error_p = "Illegal smoothing kernel types given";
+                goodParameterStatus_p = false;
+                return false;
+            }
+        }
+    }
+    else {
+        error_p = "Smoothing kernel types were not given";
+        goodParameterStatus_p = false;
+        return false;
+    }
+
+
+    // Check user gave us enough smoothing types
+
+    if (smoothAxesU.nelements() != kernelTypes_p.nelements()) {
+        error_p = "Different number of smoothing axes to kernel types";
+        goodParameterStatus_p = false;
+        return false;
+    }
+
+
+    // Now the desired smoothing kernels widths.  Allow for Hanning
+    // to not be given as it is always 1/4, 1/2, 1/4
+
+    kernelWidths_p.resize(smoothAxes_p.nelements());
+    casacore::Int nK = kernelWidthsU.size();
+    for (i=0; i<casacore::Int(smoothAxes_p.nelements()); i++) {
+        if (kernelTypes_p(i) == casacore::VectorKernel::HANNING) {
+
+            // For Hanning, width is always 3pix
+
+            casacore::Quantity tmp(3.0, casacore::String("pix"));
+            kernelWidths_p(i) = tmp;
+        }
+        else if (kernelTypes_p(i) == casacore::VectorKernel::BOXCAR) {
+
+            // For box must be odd number greater than 1
+
+            if (i > nK-1) {
+                error_p = "Not enough smoothing widths given";
+                goodParameterStatus_p = false;
+                return false;
+            }
+            else {
+                kernelWidths_p(i) = kernelWidthsU(i);
+            }
+        }
+        else if (kernelTypes_p(i) == casacore::VectorKernel::GAUSSIAN) {
+            if (i > nK-1) {
+                error_p = "Not enough smoothing widths given";
+                goodParameterStatus_p = false;
+                return false;
+            }
+            else {
+                kernelWidths_p(i) = kernelWidthsU(i);
+            }
+        }
+        else {
+            error_p = "Internal logic error";
+            goodParameterStatus_p = false;
+            return false;
+        }
+    }
+    return true;
+}
+
+template <class T>
+Bool ImageMoments<T>::setSmoothMethod(
+    const casacore::Vector<casacore::Int>& smoothAxesU,
+    const casacore::Vector<casacore::Int>& kernelTypesU,
+    const casacore::Vector<casacore::Double> & kernelWidthsPix) {
+    return MomentsBase<T>::setSmoothMethod(smoothAxesU, kernelTypesU, kernelWidthsPix);
+}
+
+template <class T>
+vector<std::shared_ptr<casacore::MaskedLattice<T> > > ImageMoments<T>::createMoments(
+    casacore::Bool doTemp, const casacore::String& outName, casacore::Bool removeAxis
+) {
+    // check whether the calculation is cancelled
+    if (_stop) {
+        return std::vector<std::shared_ptr<casacore::MaskedLattice<T>>>();
+    }
+
+    casacore::LogOrigin myOrigin("ImageMoments", __func__);
+    os_p << myOrigin;
+    if (!goodParameterStatus_p) {
+        // FIXME goodness, why are we waiting so long to throw an exception if this
+        // is the case?
+        throw casacore::AipsError("Internal status of class is bad.  You have ignored errors");
+    }
+    // Find spectral axis
+    // use a copy of the coordinate system here since, if the image has multiple beams,
+    // _image will change and hence a reference to its casacore::CoordinateSystem will disappear
+    // causing a seg fault.
+    casacore::CoordinateSystem cSys = _image->coordinates();
+    casacore::Int spectralAxis = cSys.spectralAxisNumber(false);
+    if (momentAxis_p == momentAxisDefault_p) {
+        this->setMomentAxis(spectralAxis);
+
+        // check whether the calculation is cancelled
+        if (_stop) {
+            return std::vector<std::shared_ptr<casacore::MaskedLattice<T>>>();
+        }
+
+        if (_image->shape()(momentAxis_p) <= 1) {
+            goodParameterStatus_p = false;
+            throw casacore::AipsError("Illegal moment axis; it has only 1 pixel");
+        }
+        worldMomentAxis_p = cSys.pixelAxisToWorldAxis(momentAxis_p);
+    }
+    convertToVelocity_p = (momentAxis_p == spectralAxis)
+        && (cSys.spectralCoordinate().restFrequency() > 0);
+    os_p << myOrigin;
+    casacore::String momentAxisUnits = cSys.worldAxisUnits()(worldMomentAxis_p);
+    os_p << casacore::LogIO::NORMAL << endl << "Moment axis type is "
+        << cSys.worldAxisNames()(worldMomentAxis_p) << casacore::LogIO::POST;
+    // If the moment axis is a spectral axis, indicate we want to convert to velocity
+    // Check the user's requests are allowed
+    _checkMethod();
+    // Check that input and output image names aren't the same.
+    // if there is only one output image
+    if (moments_p.nelements() == 1 && !doTemp) {
+        if(!outName.empty() && (outName == _image->name())) {
+            throw casacore::AipsError("Input image and output image have same name");
+        }
+    }
+    auto smoothClipMethod = false;
+    auto windowMethod = false;
+    auto fitMethod = false;
+    auto clipMethod = false;
+    //auto doPlot = plotter_p.isAttached();
+    if (doSmooth_p && !doWindow_p) {
+        smoothClipMethod = true;
+    }
+    else if (doWindow_p) {
+        windowMethod = true;
+    }
+    else if (doFit_p) {
+        fitMethod = true;
+    }
+    else {
+        clipMethod = true;
+    }
+    // We only smooth the image if we are doing the smooth/clip method
+    // or possibly the interactive window method.  Note that the convolution
+    // routines can only handle convolution when the image fits fully in core
+    // at present.
+    SPIIT smoothedImage;
+    if (doSmooth_p) {
+        smoothedImage = _smoothImage();
+    }
+    // Set output images shape and coordinates.
+    casacore::IPosition outImageShape;
+    const auto cSysOut = this->_makeOutputCoordinates(
+        outImageShape, cSys, _image->shape(),
+        momentAxis_p, removeAxis
+    );
+    auto nMoments = moments_p.nelements();
+    // Resize the vector of pointers for output images
+    vector<std::shared_ptr<casacore::MaskedLattice<T> > > outPt(nMoments);
+    // Loop over desired output moments
+    casacore::String suffix;
+    casacore::Bool goodUnits;
+    casacore::Bool giveMessage = true;
+    const auto imageUnits = _image->units();
+    for (casacore::uInt i=0; i<nMoments; ++i) {
+        // Set moment image units and assign pointer to output moments array
+        // Value of goodUnits is the same for each output moment image
+        casacore::Unit momentUnits;
+        goodUnits = this->_setOutThings(
+            suffix, momentUnits, imageUnits, momentAxisUnits,
+            moments_p(i), convertToVelocity_p
+        );
+        // Create output image(s).    Either casacore::PagedImage or TempImage
+        SPIIT imgp;
+        if (!doTemp) {
+            const casacore::String in = _image->name(false);
+            casacore::String outFileName;
+            if (moments_p.size() == 1) {
+                if (outName.empty()) {
+                    outFileName = in + suffix;
+                }
+                else {
+                    outFileName = outName;
+                }
+            }
+            else {
+                if (outName.empty()) {
+                    outFileName = in + suffix;
+                }
+                else {
+                    outFileName = outName + suffix;
+                }
+            }
+            if (!overWriteOutput_p) {
+                casacore::NewFile x;
+                casacore::String error;
+                if (!x.valueOK(outFileName, error)) {
+                    throw casacore::AipsError(error);
+                }
+            }
+            imgp.reset(new casacore::PagedImage<T>(outImageShape, cSysOut, outFileName));
+            os_p << casacore::LogIO::NORMAL << "Created " << outFileName << casacore::LogIO::POST;
+        }
+        else {
+            imgp.reset(new casacore::TempImage<T>(casacore::TiledShape(outImageShape), cSysOut));
+            os_p << casacore::LogIO::NORMAL << "Created TempImage" << casacore::LogIO::POST;
+        }
+        ThrowIf (! imgp, "Failed to create output file");
+        imgp->setMiscInfo(_image->miscInfo());
+        imgp->setImageInfo(_image->imageInfo());
+        imgp->appendLog(_image->logger());
+        imgp->makeMask ("mask0", true, true);
+
+        // Set output image units if possible
+
+        if (goodUnits) {
+            imgp->setUnits(momentUnits);
+        }
+        else {
+            if (giveMessage) {
+                os_p << casacore::LogIO::NORMAL
+                        << "Could not determine the units of the moment image(s) so the units " << endl;
+                os_p << "will be the same as those of the input image. This may not be very useful." << casacore::LogIO::POST;
+                giveMessage = false;
+            }
+        }
+        outPt[i] = imgp;
+    }
+    // If the user is using the automatic, non-fitting window method, they need
+    // a good assessment of the noise.  The user can input that value, but if
+    // they don't, we work it out here.
+    T noise;
+    if (stdDeviation_p <= T(0) && (doWindow_p || (doFit_p && !doWindow_p) ) ) {
+        if (smoothedImage) {
+            os_p << casacore::LogIO::NORMAL << "Evaluating noise level from smoothed image" << casacore::LogIO::POST;
+            _whatIsTheNoise(noise, *smoothedImage);
+        }
+        else {
+            os_p << casacore::LogIO::NORMAL << "Evaluating noise level from input image" << casacore::LogIO::POST;
+            _whatIsTheNoise (noise, *_image);
+        }
+        stdDeviation_p = noise;
+    }
+
+    // Create appropriate MomentCalculator object
+    os_p << casacore::LogIO::NORMAL << "Begin computation of moments" << casacore::LogIO::POST;
+    shared_ptr<MomentCalcBase<T> > momentCalculator;
+    if (clipMethod || smoothClipMethod) {
+        momentCalculator.reset(
+            new MomentClip<T>(smoothedImage, *this, os_p, outPt.size())
+        );
+    }
+    else if (windowMethod) {
+        momentCalculator.reset(
+            new MomentWindow<T>(smoothedImage, *this, os_p, outPt.size())
+        );
+    }
+    else if (fitMethod) {
+        momentCalculator.reset(
+            new MomentFit<T>(*this, os_p, outPt.size())
+        );
+    }
+    // Iterate optimally through the image, compute the moments, fill the output lattices
+    casacore::uInt n = outPt.size();
+    casacore::PtrBlock<casacore::MaskedLattice<T>* > ptrBlock(n);
+    for (casacore::uInt i=0; i<n; ++i) {
+        ptrBlock[i] = outPt[i].get();
+    }
+    lineMultiApply(ptrBlock, *_image, *momentCalculator, momentAxis_p);
+    if (windowMethod || fitMethod) {
+        if (momentCalculator->nFailedFits() != 0) {
+            os_p << casacore::LogIO::NORMAL << "There were "
+                <<  momentCalculator->nFailedFits()
+                << " failed fits" << casacore::LogIO::POST;
+        }
+    }
+
+    if (_stop) {
+        for (auto& p: outPt) {
+            p.reset();
+        }
+        outPt.clear();
+    } else {
+        for (auto& p: outPt) {
+            p->flush();
+        }
+    }
+
+    return outPt;
+}
+
+template <class T> SPIIT ImageMoments<T>::_smoothImage() {
+    // casacore::Smooth image.   casacore::Input masked pixels are zerod before smoothing.
+    // The output smoothed image is masked as well to reflect
+    // the input mask.
+    auto axMax = max(smoothAxes_p) + 1;
+    ThrowIf(
+        axMax > casacore::Int(_image->ndim()),
+        "You have specified an illegal smoothing axis"
+    );
+    SPIIT smoothedImage;
+    if (smoothOut_p.empty()) {
+        smoothedImage.reset(
+            new casacore::TempImage<T>(
+                _image->shape(),
+                _image->coordinates()
+            )
+        );
+    }
+    else {
+        // This image has already been checked in setSmoothOutName
+        // to not exist
+        smoothedImage.reset(
+            new casacore::PagedImage<T>(
+                _image->shape(),
+                _image->coordinates(), smoothOut_p
+            )
+        );
+    }
+    smoothedImage->setMiscInfo(_image->miscInfo());
+    // Do the convolution.  Conserve flux.
+    SepImageConvolver<T> sic(*_image, os_p, true);
+    auto n = smoothAxes_p.size();
+    for (casacore::uInt i=0; i<n; ++i) {
+        casacore::VectorKernel::KernelTypes type = casacore::VectorKernel::KernelTypes(kernelTypes_p[i]);
+        sic.setKernel(
+            casacore::uInt(smoothAxes_p[i]), type, kernelWidths_p[i],
+            true, false, 1.0
+        );
+    }
+    sic.convolve(*smoothedImage);
+    return smoothedImage;
+}
+
+template <class T> 
+void ImageMoments<T>::_whatIsTheNoise (
+    T& sigma, const casacore::ImageInterface<T>& image
+) {
+    // Determine the noise level in the image by first making a histogram of
+    // the image, then fitting a Gaussian between the 25% levels to give sigma
+    // Find a histogram of the image
+    ImageHistograms<T> histo(image, false);
+    const casacore::uInt nBins = 100;
+    histo.setNBins(nBins);
+    // It is safe to use casacore::Vector rather than casacore::Array because
+    // we are binning the whole image and ImageHistograms will only resize
+    // these Vectors to a 1-D shape
+    casacore::Vector<T> values, counts;
+    ThrowIf(
+        ! histo.getHistograms(values, counts),
+        "Unable to make histogram of image"
+    );
+    // Enter into a plot/fit loop
+    auto binWidth = values(1) - values(0);
+    T xMin, xMax, yMin, yMax;
+    xMin = values(0) - binWidth;
+    xMax = values(nBins-1) + binWidth;
+    casacore::Float xMinF = casacore::Float(real(xMin));
+    casacore::Float xMaxF = casacore::Float(real(xMax));
+    casacore::LatticeStatsBase::stretchMinMax(xMinF, xMaxF);
+    casacore::IPosition yMinPos(1), yMaxPos(1);
+    minMax (yMin, yMax, yMinPos, yMaxPos, counts);
+    casacore::Float yMaxF = casacore::Float(real(yMax));
+    yMaxF += yMaxF/20;
+    auto first = true;
+    auto more = true;
+    while (more) {
+        casacore::Int iMin = 0;
+        casacore::Int iMax = 0;
+        if (first) {
+            first = false;
+            iMax = yMaxPos(0);
+            casacore::uInt i;
+            for (i=yMaxPos(0); i<nBins; i++) {
+                if (counts(i) < yMax/4) {
+                    iMax = i;
+                    break;
+                }
+            }
+            iMin = yMinPos(0);
+            for (i=yMaxPos(0); i>0; i--) {
+                if (counts(i) < yMax/4) {
+                    iMin = i;
+                    break;
+                }
+            }
+            // Check range is sensible
+            if (iMax <= iMin || abs(iMax-iMin) < 3) {
+                os_p << casacore::LogIO::NORMAL << "The image histogram is strangely shaped, fitting to all bins" << casacore::LogIO::POST;
+                iMin = 0;
+                iMax = nBins-1;
+            }
+        }
+        // Now generate the distribution we want to fit.  Normalize to
+        // peak 1 to help fitter.
+        const casacore::uInt nPts2 = iMax - iMin + 1;
+        casacore::Vector<T> xx(nPts2);
+        casacore::Vector<T> yy(nPts2);
+        casacore::Int i;
+        for (i=iMin; i<=iMax; i++) {
+            xx(i-iMin) = values(i);
+            yy(i-iMin) = counts(i)/yMax;
+        }
+        // Create fitter
+        casacore::NonLinearFitLM<T> fitter;
+        casacore::Gaussian1D<casacore::AutoDiff<T> > gauss;
+        fitter.setFunction(gauss);
+        // Initial guess
+        casacore::Vector<T> v(3);
+        v(0) = 1.0;                          // height
+        v(1) = values(yMaxPos(0));           // position
+        v(2) = nPts2*binWidth/2;             // width
+        // Fit
+        fitter.setParameterValues(v);
+        fitter.setMaxIter(50);
+        T tol = 0.001;
+        fitter.setCriteria(tol);
+        casacore::Vector<T> resultSigma(nPts2);
+        resultSigma = 1;
+        casacore::Vector<T> solution;
+        casacore::Bool fail = false;
+        try {
+            solution = fitter.fit(xx, yy, resultSigma);
+        }
+        catch (const casacore::AipsError& x) {
+            fail = true;
+        }
+        // Return values of fit
+        if (! fail && fitter.converged()) {
+            sigma = T(abs(solution(2)) / C::sqrt2);
+            os_p << casacore::LogIO::NORMAL
+                    << "*** The fitted standard deviation of the noise is " << sigma
+                    << endl << casacore::LogIO::POST;
+        }
+        else {
+            os_p << casacore::LogIO::WARN << "The fit to determine the noise level failed." << endl;
+            os_p << "Try inputting it directly" << endl;
+        }
+        // Another go
+        more = false;
+    }
+}
+
+template <class T>
+void ImageMoments<T>::setProgressMonitor( ImageMomentsProgressMonitor* monitor ) {
+    if (showProgress_p && monitor) { // set the progress meter
+        if (!_progressMonitor) {
+          _progressMonitor.reset(new casa::ImageMomentsProgress());
+        }
+        _progressMonitor->setProgressMonitor(monitor);
+    }
+}
+
+template <class T>
+void ImageMoments<T>::lineMultiApply(
+    casacore::PtrBlock<casacore::MaskedLattice<T>*>& latticeOut,
+    const casacore::MaskedLattice<T>& latticeIn,
+    casacore::LineCollapser<T, T>& collapser, casacore::uInt collapseAxis) {
+    // First verify that all the output lattices have the same shape and tile shape
+    const casacore::uInt nOut = latticeOut.nelements();
+    AlwaysAssert(nOut > 0, AipsError);
+
+    const casacore::IPosition outShape(latticeOut[0]->shape());
+    const casacore::uInt outDim = outShape.nelements();
+    for (casacore::uInt i = 1; i < nOut; ++i) {
+        AlwaysAssert(latticeOut[i]->shape() == outShape, AipsError);
+    }
+
+    const casacore::IPosition& inShape = latticeIn.shape();
+
+    // Does the input has a mask? If not, can the collapser handle a null mask.
+    casacore::Bool useMask = latticeIn.isMasked() ? casacore::True : (!collapser.canHandleNullMask());
+    const casacore::uInt inNdim = inShape.size();
+    const casacore::IPosition displayAxes = IPosition::makeAxisPath(inNdim).otherAxes(inNdim, IPosition(1, collapseAxis));
+
+    casacore::Vector<T> result(nOut);
+    casacore::Vector<casacore::Bool> resultMask(nOut);
+
+    // Read in larger chunks than before, and then do the accounting for the
+    // input lines in memory
+    casacore::IPosition chunkSliceStart(inNdim, 0);
+    casacore::IPosition chunkSliceEnd = chunkSliceStart;
+    chunkSliceEnd[collapseAxis] = inShape[collapseAxis] - 1;
+    const casacore::IPosition chunkSliceEndAtChunkIterBegin = chunkSliceEnd;
+
+    // Get a chunk shape and used it to set the data iterator
+    casacore::IPosition chunkShapeInit = chunkShape(collapseAxis, latticeIn);
+
+    casacore::IPosition hdf5ChunkShape(inNdim, 1);
+    hdf5ChunkShape[0] = 512;
+    hdf5ChunkShape[1] = 512;
+
+    auto niceShape = latticeIn.niceCursorShape();
+    if (niceShape == hdf5ChunkShape) {
+        chunkShapeInit[0] = niceShape[0];
+        chunkShapeInit[1] = niceShape[1];
+    }
+
+    casacore::LatticeStepper myStepper(inShape, chunkShapeInit, LatticeStepper::RESIZE);
+    casacore::RO_MaskedLatticeIterator<T> latIter(latticeIn, myStepper);
+
+    casacore::IPosition curPos;
+    static const casacore::Vector<casacore::Bool> noMask;
+
+    if (_progressMonitor && (_stepsForBeamConvolution == 0)) {
+        // no beam convolution done before, so initialize the progress meter
+        casacore::uInt totalSlices = inShape.product() / inShape[collapseAxis];
+        _progressMonitor->init(totalSlices);
+    }
+
+    casacore::uInt nDone = 0; // Number of slices have done
+
+    // Iterate through a cube image, chunk by chunk
+    for (latIter.reset(); !latIter.atEnd(); ++latIter) {
+        const casacore::IPosition iterPos = latIter.position();
+        const casacore::Array<T>& chunk = latIter.cursor();
+        casacore::IPosition chunkShape = chunk.shape();
+        const casacore::Array<casacore::Bool> mask_chunk = useMask ? latIter.getMask() : Array<Bool>();
+
+        chunkSliceStart = 0;
+        chunkSliceEnd = chunkSliceEndAtChunkIterBegin;
+        casacore::IPosition resultArrayShape = chunkShape;
+        resultArrayShape[collapseAxis] = 1;
+        std::vector<casacore::Array<T>> resultArrays(nOut);
+        std::vector<casacore::Array<casacore::Bool>> resultArrayMasks(nOut);
+
+        // Need to initialize this way rather than doing it in the constructor,
+        // because using a single Array in the constructor means that
+        // all Arrays in the vector reference the same Array.
+        for (casacore::uInt k = 0; k < nOut; k++) {
+            resultArrays[k] = Array<T>(resultArrayShape);
+            resultArrayMasks[k] = Array<Bool>(resultArrayShape);
+        }
+
+        // Iterate through a chunk, slice by slice on the output image display axes
+        casacore::Bool done = casacore::False;
+        while (!done) {
+            if (_stop) { // Break the iteration in a chunk
+                 break;
+            }
+
+            casacore::Vector<T> data(chunk(chunkSliceStart, chunkSliceEnd));
+            casacore::Vector<Bool> mask =
+                useMask ? casacore::Vector<casacore::Bool>(mask_chunk(chunkSliceStart, chunkSliceEnd)) : noMask;
+            curPos = iterPos + chunkSliceStart;
+
+            // Do collapse calculations
+            collapser.multiProcess(result, resultMask, data, mask, curPos);
+
+            // Fill partial results in a chunk
+            for (uInt k = 0; k < nOut; ++k) {
+                resultArrays[k](chunkSliceStart) = result[k];
+                resultArrayMasks[k](chunkSliceStart) = resultMask[k];
+            }
+
+            done = True; // The scan of this chunk is completed
+
+            // Report the number of slices have done
+            if (_progressMonitor) {
+                ++nDone;
+                _progressMonitor->nstepsDone(nDone + _stepsForBeamConvolution);
+            }
+
+            // Proceed to the next slice on the display axes
+            for (casacore::uInt k = 0; k < displayAxes.size(); ++k) {
+                casacore::uInt dax = displayAxes[k];
+                if (chunkSliceStart[dax] < chunkShape[dax] - 1) {
+                    ++chunkSliceStart[dax];
+                    ++chunkSliceEnd[dax];
+                    done = False;
+                    break;
+                } else {
+                    chunkSliceStart[dax] = 0;
+                    chunkSliceEnd[dax] = 0;
+                }
+            }
+        }
+
+        if (_stop) { // Break the iteration in a cube image
+            break;
+        }
+
+        // Put partial results in output lattices (chunk by chunk)
+        for (casacore::uInt k = 0; k < nOut; ++k) {
+            casacore::IPosition resultPos = inNdim == outDim ? iterPos : iterPos.removeAxes(casacore::IPosition(1, collapseAxis));
+            casacore::Bool keepAxis = resultArrays[k].ndim() == latticeOut[k]->ndim();
+            if (!keepAxis) {
+                resultArrays[k].removeDegenerate(displayAxes);
+            }
+            latticeOut[k]->putSlice(resultArrays[k], resultPos);
+
+            if (latticeOut[k]->hasPixelMask()) {
+                casacore::Lattice<casacore::Bool>& maskOut = latticeOut[k]->pixelMask();
+                if (maskOut.isWritable()) {
+                    if (!keepAxis) {
+                        resultArrayMasks[k].removeDegenerate(displayAxes);
+                    }
+                    maskOut.putSlice(resultArrayMasks[k], resultPos);
+                }
+            }
+        }
+    }
+
+    if (_progressMonitor) {
+        _progressMonitor->done();
+    }
+}
+
+template <class T>
+casacore::IPosition ImageMoments<T>::chunkShape(casacore::uInt axis,
+    const casacore::MaskedLattice<T>& latticeIn) {
+    casacore::uInt ndim = latticeIn.ndim();
+    casacore::IPosition chunkShape(ndim, 1);
+    casacore::IPosition latInShape = latticeIn.shape();
+    casacore::uInt axisLength = latInShape[axis];
+    chunkShape[axis] = axisLength;
+
+    // arbitrary, but reasonable, max memory limit in bytes for storing arrays in bytes
+    static const casacore::uInt limit = 2e7; // Set the limit of memory usage (Bytes)
+    static const casacore::uInt sizeOfT = sizeof(T);
+    static const casacore::uInt sizeOfBool = sizeof(casacore::Bool);
+    casacore::uInt chunkMult = latticeIn.isMasked() ? sizeOfT + sizeOfBool : sizeOfT;
+
+    // Memory size for a sub-chunk (Bytes), i.e., memory for a specific axis line
+    casacore::uInt subChunkSize = chunkMult * axisLength;
+
+    // Chunk size, i.e., number of pixels on display axes
+    const casacore::uInt chunkSize = limit / subChunkSize;
+    if (chunkSize <= 1) {
+        // can only go row by row
+        return chunkShape;
+    }
+
+    ssize_t x = chunkSize;
+    for (casacore::uInt i = 0; i < ndim; ++i) {
+        if (i != axis) {
+            chunkShape[i] = std::min(x, latInShape[i]);
+            // integer division
+            x /= chunkShape[i];
+            if (x == 0) {
+                break;
+            }
+        }
+    }
+    return chunkShape;
+}
+
+template <class T>
+void ImageMoments<T>::stopCalculation() {
+    _stop = true;
+    if (_image2dConvolver) {
+        _image2dConvolver->stopCalculation();
+    }
+}
+
+}
+


### PR DESCRIPTION
It is related to #15. I modify CASA codes `ImageMoments` and `Image2DConvolver` in order to enable the cancellation for the moment generator. The behavior for the moment generator is not changed in the CASA viewer. @pford will open a PR for these changes and go into the CASA master branch (version 6.4) in August. Now I temporarily put modified files in the folder `modified_files`. During compiling, these files will overwrite the same file names in the directory `carta-casacore/imageanalysis/ImageAnalysis/`. This branch is used to test these modified files with the corresponding CARTA backend branch ([PR 856](https://github.com/CARTAvis/carta-backend/pull/856)).