### PR TITLE
changing the .casarc file location to .carta/casarc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ include(CheckCCompilerFlag)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 
+# Change ~/.casarc to ~/.carta/casarc to facilitate updating the CASA measures data in CARTA.
+add_custom_target(casarc_patch
+    COMMAND sed -i.orig 's|/.casarc:|/.carta/casarc:|g' ${CMAKE_SOURCE_DIR}/casa6/casatools/casacore/casa/System/Aipsrc.cc
+)
+
 # fixes warnings on cmake 3.x+ For now we want the old behavior to be backwards compatible
 if (POLICY CMP0048)
     cmake_policy (SET CMP0048 OLD)


### PR DESCRIPTION
Could we also merge this change before we create the new carta-casacore 6.5.0.4 Deb and RPM packages please?
I believe it is the easiest way to enable us to update the CASA measures data that CARTA will use.
The `casarc` file is used by casacore to automatically override the default search location of the measures data.
Instead of checking for `~/.casarc`, it will check for `~/.carta/casarc`. 
Moving it to `~/.carta/casarc` will ensure that we do not interfere with any CASA or other casacore installations on the user's computer.