### PR TITLE
add_custom_target requires an ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ include(CheckCCompilerFlag)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 
-# Change ~/.casarc to ~/.carta/casarc to facilitate updating the CASA measures data in CARTA.
+# Change ~/.casarc to ~/.carta-casacore/casarc to facilitate updating the CASA measures data in CARTA.
 add_custom_target(casarc_patch ALL
-    COMMAND sed -i.orig 's|/.casarc:|/.carta/casarc:|g' ${CMAKE_SOURCE_DIR}/casa6/casatools/casacore/casa/System/Aipsrc.cc
+    COMMAND sed -i.orig 's|/.casarc:|/.carta-casacore/casarc:|g' ${CMAKE_SOURCE_DIR}/casa6/casatools/casacore/casa/System/Aipsrc.cc
 )
 
 # fixes warnings on cmake 3.x+ For now we want the old behavior to be backwards compatible

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 
 # Change ~/.casarc to ~/.carta/casarc to facilitate updating the CASA measures data in CARTA.
-add_custom_target(casarc_patch
+add_custom_target(casarc_patch ALL
     COMMAND sed -i.orig 's|/.casarc:|/.carta/casarc:|g' ${CMAKE_SOURCE_DIR}/casa6/casatools/casacore/casa/System/Aipsrc.cc
 )
 


### PR DESCRIPTION
I'm very sorry, I made a mistake in the previous PR. The `add_custom_target` was not actually running because it was missing an `ALL`! This means we would need to rebuild the carta-casacore RPM and Debian packages...

The only bright side is that this could be an opportunity to incorporate @confluence's suggestion of using the location of `~/.carta-casacore/casarc` instead of `~/.carta/casarc` to make the scheme work on the beta releases that use `~/.carta-beta`. What do you think?