### PR TITLE
Prevent some update script failure cases

### DIFF
--- a/scripts/casa_data_autoupdate.sh
+++ b/scripts/casa_data_autoupdate.sh
@@ -4,21 +4,29 @@ UPDATE_INTERVAL=7
 AUTOUPDATE_ENABLED="false"
 CASA_DATA_USER_DIR="$HOME/.carta-casacore/data"
 CASARC_FILE="$HOME/.carta-casacore/casarc"
+CARTA_CONFIG_FILE="$HOME/.carta/config/preferences.json"
 
 function check_json_settings {
+    if [ ! -f "$CARTA_CONFIG_FILE" ]
+    then
+        return
+    fi    
     # False JSON parsing
     # Remove spaces, comma, and quotes, then replace colon with one space to get two columns of key-value pairs
     # Finally filter the key-value pair using awk and print the value (2nd column)
-    JSON_AUTO_UPDATE_CASA=$(cat ~/.carta/config/preferences.json | sed -e 's/[",{}]//g;s/[[:space:]]//g;s/:/ /g' | awk -F" " '$1=="auto_update_casa_data" {print $2}')
+    JSON_AUTO_UPDATE_CASA=$(cat $CARTA_CONFIG_FILE | sed -e 's/[",{}]//g;s/[[:space:]]//g;s/:/ /g' | awk -F" " '$1=="auto_update_casa_data" {print $2}')
     if [ "$JSON_AUTO_UPDATE_CASA" == "true" ]
     then
         AUTOUPDATE_ENABLED="true"
     fi
     JSON_AUTO_UPDATE_CASA_DATA_INTERVAL=0
-    JSON_AUTO_UPDATE_CASA_DATA_INTERVAL=$(cat ~/.carta/config/preferences.json | sed -e 's/[",{}]//g;s/[[:space:]]//g;s/:/ /g' | awk -F" " '$1=="auto_update_casa_data_interval" {print $2}')
-    if [ $JSON_AUTO_UPDATE_CASA_DATA_INTERVAL -gt 0 ]
+    JSON_AUTO_UPDATE_CASA_DATA_INTERVAL=$(cat $CARTA_CONFIG_FILE | sed -e 's/[",{}]//g;s/[[:space:]]//g;s/:/ /g' | awk -F" " '$1=="auto_update_casa_data_interval" {print $2}')
+    if [ ! -z "$JSON_AUTO_UPDATE_CASA_DATA_INTERVAL" ]
     then
-        UPDATE_INTERVAL=$JSON_AUTO_UPDATE_CASA_DATA_INTERVAL
+        if [ $JSON_AUTO_UPDATE_CASA_DATA_INTERVAL -gt 0 ]
+        then
+            UPDATE_INTERVAL=$JSON_AUTO_UPDATE_CASA_DATA_INTERVAL
+        fi
     fi
 }
 
@@ -107,7 +115,5 @@ function autoupdate_if_needed {
 # Logic starts here
 # Check JSON for preferences.json settings
 check_json_settings
-echo "AUTOUPDATE ENABLED = $AUTOUPDATE_ENABLED"
-echo "UPDATE INTERVAL = $UPDATE_INTERVAL"
 # Launch auto update
 autoupdate_if_needed


### PR DESCRIPTION
This ensures that the script does not attempt to read from the hardcoded config file if it does not exist (which can happen if a release version has never been installed in the environment), and does not fail with an operator error if the file does not contain the expected preferences (which happens if the numeric preference is empty when it is used in the comparison).

I have also removed the echoing of the update setting and update interval at the end. The update function already prints more user-friendly information about what the script is doing, and if updates are not enabled this additional information is irrelevant to the user.