### PR TITLE
Update casa6 submodule to v6.7.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,10 @@ if (EXISTS /opt/casa/03/lib)
 endif()
 
 add_definitions( -DDBUS_CPP )
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-cmake_minimum_required (VERSION 3.3.0)
+cmake_minimum_required (VERSION 3.14.0)
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 include(CheckFunctionExists)
@@ -39,13 +40,13 @@ if (POLICY CMP0074)
 endif()
 
 set(PROJECT_VERSION_MAJOR 3)
-set(PROJECT_VERSION_MINOR 5)
-set(PROJECT_VERSION_PATCH 0)
+set(PROJECT_VERSION_MINOR 6)
+set(PROJECT_VERSION_PATCH 1)
 set(PROJECT_VERSION
   "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 # Increment the PROJECT_SOVERSION every time you update VERSION_MINOR!
-SET(PROJECT_SOVERSION 7)
+SET(PROJECT_SOVERSION 8)
 
 SET(NO_SOVERSION FALSE CACHE BOOL "do not add version information to shared libraries")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -222,13 +223,13 @@ if (NOT CMAKE_BUILD_TYPE)
     endif(_cmpvar STREQUAL "dbg" OR _cmpvar STREQUAL "debug")
 endif (NOT CMAKE_BUILD_TYPE)
 
-# Detect if the compiler supports C++11 if we want to use it.
-check_cxx_compiler_flag(-std=c++11 HAS_CXX11)
-if (HAS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# Detect if the compiler supports C++17 if we want to use it.
+check_cxx_compiler_flag(-std=c++17 HAS_CXX17)
+if (HAS_CXX17)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 else()
-    message(FATAL_ERROR "Casacore build requires a c++11 compatible compiler")
-endif (HAS_CXX11)
+    message(FATAL_ERROR "Casacore build requires a c++17 compatible compiler")
+endif (HAS_CXX17)
 
 # use faster fortran rules for complex operations, removes restoring complex
 # infinities if naive computation results in NAN + NAN * I

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,7 +537,7 @@ endif (NOT BUILD_TESTING)
 # Custom SOVERSION for imageanalysis is derived from the casa minor version rather than the casacore minor version.
 # Check git tags for CASA version (currently 6.6.0)
 # If the minor version has changed, bump this:
-set( CASA_PROJECT_SOVERSION   6   )
+set( CASA_PROJECT_SOVERSION   7   )
 
 # Determine the SOVERSION and define as compile variable.
 if (casa_soversion)


### PR DESCRIPTION
Closes #30 .

This PR updates:

- casa6 submodule to latest release version 6.7.3
- casa6 casacore submodule to commit from February 2025 (in release 3.7.0)
- CMakeLists.txt to match casacore's CMakeLists.txt.
- Use carta-backend 1499_update_casa6 branch (CARTAvis/carta-backend#1527)

Note that many deprecation warnings still exist when compiling carta-casacore.  Casacore deprecated its constants in casa/BasicSL/Constants.h but has not removed the use of its constants from its code base (for example: `warning: 'pi' is deprecated: use M_PI`) and has not removed deprecated std library usage such as:

```
warning: 'iterator<std::random_access_iterator_tag, float>' is deprecated
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.
```

We expect the casacore submodule to be updated in CASA by the end of this year.  If that happens, carta-casacore will be updated again, and hopefully some of these deprecation warnings will be removed.